### PR TITLE
fix: back button falls back to home when opened from notification

### DIFF
--- a/frontend/src/pages/EventDetailPage.jsx
+++ b/frontend/src/pages/EventDetailPage.jsx
@@ -598,7 +598,7 @@ export default function EventDetailPage() {
         {/* ========== MOBILE HEADER (Back button - iOS only, fixed overlay) ========== */}
         {isIOS && (
           <button
-            onClick={() => navigate(-1)}
+            onClick={() => window.history.length > 1 ? navigate(-1) : navigate('/')}
             className="sm:hidden fixed top-20 left-4 z-[1000] flex items-center justify-center w-10 h-10 rounded-full bg-white/90 backdrop-blur-md shadow-xl text-gray-600 hover:text-purple-600 active:scale-95 transition-all"
           >
             <ArrowLeft className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- Back button on EventDetailPage called `navigate(-1)` which is a no-op when the event is opened directly from a push notification (no prior history)
- Now falls back to `navigate('/')` when `window.history.length <= 1`
- Normal in-app navigation is unaffected — `navigate(-1)` still used when history exists

## Test plan
- [x] Open an event normally from the home page → back button returns to previous page
- [x] Tap a push notification that opens an event directly → back button goes to home page
- [x] Verify on iOS PWA (primary affected surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)