### PR TITLE
fix: display group banner image on Event Detail Page

### DIFF
--- a/backend/src/main/java/com/organiser/platform/dto/EventDTO.java
+++ b/backend/src/main/java/com/organiser/platform/dto/EventDTO.java
@@ -25,6 +25,7 @@ public class EventDTO {
     private String activityTypeName;
     private Long groupId;
     private String groupName;
+    private String groupImageUrl;
     private Long hostMemberId;
     private String hostMemberName;
     private Instant eventDate;  // UTC timestamp for proper timezone handling

--- a/backend/src/main/java/com/organiser/platform/service/EventService.java
+++ b/backend/src/main/java/com/organiser/platform/service/EventService.java
@@ -720,6 +720,7 @@ public class EventService {
                 .activityTypeName(activity.getName())
                 .groupId(group.getId())
                 .groupName(group.getName())
+                .groupImageUrl(group.getImageUrl())
                 .hostMemberId(hostMemberId)
                 .hostMemberName(hostMemberName)
                 .eventDate(event.getEventDate())
@@ -815,6 +816,7 @@ public class EventService {
                 .activityTypeName(activity.getName())
                 .groupId(group.getId())
                 .groupName(group.getName())
+                .groupImageUrl(group.getImageUrl())
                 .hostMemberId(hostMemberId)
                 .hostMemberName(hostMemberName)
                 .eventDate(event.getEventDate())
@@ -885,6 +887,7 @@ public class EventService {
                 .activityTypeName(activity.getName())
                 .groupId(group.getId())
                 .groupName(group.getName())
+                .groupImageUrl(group.getImageUrl())
                 .eventDate(event.getEventDate())
                 .imageUrl(null) // Hide image from non-members
                 .status(event.getStatus())

--- a/frontend/src/pages/EventDetailPage.jsx
+++ b/frontend/src/pages/EventDetailPage.jsx
@@ -1109,9 +1109,9 @@ export default function EventDetailPage() {
                 <div className="flex items-center gap-3 pl-2">
                   {/* Group banner thumbnail */}
                   <div className="w-10 h-10 flex-shrink-0 bg-gradient-to-br from-purple-500 to-pink-500 rounded-xl overflow-hidden relative">
-                    {event?.group?.bannerUrl ? (
+                    {event?.groupImageUrl ? (
                       <img
-                        src={event.group.bannerUrl}
+                        src={event.groupImageUrl}
                         alt={displayEvent.groupName}
                         className="w-full h-full object-cover"
                       />


### PR DESCRIPTION
## Problem
The group card on the Event Detail Page always showed a fallback Mountain icon instead of the group's actual banner image, even when the group has a banner.

## Root Cause
`EventDTO` had no field for the group's image URL. The frontend checked `event.group.bannerUrl` which was always `undefined` — group data is returned as flat fields (`groupId`, `groupName`, etc.), not a nested object.

## Changes
- **`EventDTO.java`** — Added `groupImageUrl` field
- **`EventService.java`** — Populate `groupImageUrl` from `group.getImageUrl()` in all 3 `convertToDTO`/`convertToPartialDTO` methods
- **`EventDetailPage.jsx`** — Use `event.groupImageUrl` instead of `event?.group?.bannerUrl`

## Testing
- Groups **with** a banner image now display the image in the group card thumbnail
- Groups **without** a banner image still show the Mountain icon fallback