### PR TITLE
feat: SEO and LLM-SEO improvements for day hike London ranking

### DIFF
--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -6,7 +6,7 @@
 # Edge Functions for dynamic Open Graph tags
 [[edge_functions]]
   function = "og-tags"
-  path = "/events/*"
+  path = "/*"
 
 # SPA redirect rules (fallback to _redirects file)
 [[redirects]]

--- a/frontend/netlify/edge-functions/og-tags.js
+++ b/frontend/netlify/edge-functions/og-tags.js
@@ -9,156 +9,291 @@ function escapeHtml(str) {
     .replace(/"/g, '&quot;');
 }
 
-export default async (request, context) => {
-  const url = new URL(request.url);
-  
-  // Only handle event detail pages
-  const eventMatch = url.pathname.match(/^\/events\/(\d+)$/);
-  
-  if (!eventMatch) {
-    // Not an event page, serve normally
-    return context.next();
+// Detect bots: social crawlers + search engine crawlers (Googlebot, Bingbot, etc.)
+function isCrawlerRequest(userAgent) {
+  return /googlebot|google-inspectiontool|adsbot-google|bingbot|slurp|duckduckbot|yandexbot|baiduspider|sogou|exabot|facebot|ia_archiver|rogerbot|linkedinbot|bot|crawler|spider|facebookexternalhit|twitterbot|instagram|whatsapp|slackbot|discordbot|embedly|pinterest|flipboard|tumblr|skypeuripreview|vkshare|google-structured-data-testing-tool/i.test(userAgent);
+}
+
+async function injectMetaTags(context, { title, description, url, image, schema }) {
+  const htmlResponse = await context.next();
+  let html = await htmlResponse.text();
+  const safeImage = image || 'https://www.outmeets.com/og-image.jpg';
+
+  html = html
+    .replace(/<title>.*?<\/title>/, `<title>${escapeHtml(title)}</title>`)
+    .replace(/<meta name="description" content=".*?"\s*\/?>/, `<meta name="description" content="${escapeHtml(description)}">`)
+    .replace(/<meta property="og:title" content=".*?"\s*\/?>/, `<meta property="og:title" content="${escapeHtml(title)}">`)
+    .replace(/<meta property="og:description" content=".*?"\s*\/?>/, `<meta property="og:description" content="${escapeHtml(description)}">`)
+    .replace(/<meta property="og:image" content=".*?"\s*\/?>/, `<meta property="og:image" content="${escapeHtml(safeImage)}">`)
+    .replace(/<meta property="og:url" content=".*?"\s*\/?>/, `<meta property="og:url" content="${escapeHtml(url)}">`)
+    .replace(/<meta name="twitter:title" content=".*?"\s*\/?>/, `<meta name="twitter:title" content="${escapeHtml(title)}">`)
+    .replace(/<meta name="twitter:description" content=".*?"\s*\/?>/, `<meta name="twitter:description" content="${escapeHtml(description)}">`)
+    .replace(/<meta name="twitter:url" content=".*?"\s*\/?>/, `<meta name="twitter:url" content="${escapeHtml(url)}">`);
+
+  if (schema) {
+    const safeJsonLd = JSON.stringify(schema).replace(/</g, '\\u003c');
+    html = html.replace('</head>', `<script type="application/ld+json">${safeJsonLd}</script></head>`);
   }
-  
-  const eventId = eventMatch[1];
-  
-  // Check if this is a bot/crawler (Instagram, Facebook, Twitter, etc.)
-  const userAgent = request.headers.get('user-agent') || '';
-  const isCrawler = /bot|crawler|spider|facebookexternalhit|twitterbot|instagram/i.test(userAgent);
-  
-  if (!isCrawler) {
-    // Regular user, serve the SPA normally
-    return context.next();
-  }
-  
-  // Fetch event data from backend API
+
+  // Inject canonical URL
+  const canonicalTag = `<link rel="canonical" href="${escapeHtml(url)}" />`;
+  html = html.replace(/<link rel="canonical" href=".*?"\s*\/?>/, canonicalTag);
+
+  return new Response(html, {
+    headers: {
+      'content-type': 'text/html;charset=UTF-8',
+      'cache-control': 'public, max-age=300',
+    },
+  });
+}
+
+async function handleEventPage(request, context, eventId) {
   const backendUrl = Netlify.env.get('BACKEND_API_URL') || 'https://hikehub-backend-nd4r.onrender.com';
   const apiUrl = `${backendUrl}/api/v1/events/public/${eventId}`;
-  
+
   try {
     const response = await fetch(apiUrl);
-    
-    if (!response.ok) {
-      return context.next();
-    }
-    
+    if (!response.ok) return context.next();
+
     const event = await response.json();
-    
-    // Generate dynamic meta tags (escaped to prevent XSS)
-    const title = escapeHtml(event.title ? `${event.title} | OutMeets` : 'OutMeets');
-    const rawDescription = event.description 
+
+    const rawDescription = event.description
       ? (event.description.length > 160 ? event.description.substring(0, 160) + '...' : event.description)
       : `Join this hiking event on ${new Date(event.eventDate).toLocaleDateString('en-GB', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}`;
-    const description = escapeHtml(rawDescription);
-    const image = event.imageUrl || 'https://www.outmeets.com/og-image.jpg';
+
     const eventUrl = `https://www.outmeets.com/events/${eventId}`;
-    
-    // Get the base HTML
+    const image = event.imageUrl || 'https://www.outmeets.com/og-image.jpg';
+
+    const schema = {
+      '@context': 'https://schema.org',
+      '@type': 'Event',
+      'name': event.title,
+      'description': event.description || '',
+      'startDate': event.eventDate,
+      'endDate': event.endDate || event.eventDate,
+      'eventStatus': 'https://schema.org/EventScheduled',
+      'eventAttendanceMode': 'https://schema.org/OfflineEventAttendanceMode',
+      'location': {
+        '@type': 'Place',
+        'name': event.location,
+        'address': event.location,
+      },
+      'image': image,
+      'organizer': {
+        '@type': 'Organization',
+        'name': 'OutMeets',
+        'url': 'https://www.outmeets.com',
+      },
+      ...(event.price > 0 ? {
+        'offers': {
+          '@type': 'Offer',
+          'price': event.price,
+          'priceCurrency': 'GBP',
+          'availability': 'https://schema.org/InStock',
+          'url': eventUrl,
+        },
+      } : {}),
+    };
+
     const htmlResponse = await context.next();
     let html = await htmlResponse.text();
-    
-    // Replace default meta tags with event-specific ones
+
+    const title = escapeHtml(event.title ? `${event.title} | OutMeets` : 'OutMeets');
+    const description = escapeHtml(rawDescription);
+
     html = html
-      // Title
-      .replace(
-        /<title>.*?<\/title>/,
-        `<title>${title}</title>`
-      )
-      // Description
-      .replace(
-        /<meta name="description" content=".*?"\s*\/?>/,
-        `<meta name="description" content="${description}">`
-      )
-      // OG tags
-      .replace(
-        /<meta property="og:title" content=".*?"\s*\/?>/,
-        `<meta property="og:title" content="${title}">`
-      )
-      .replace(
-        /<meta property="og:description" content=".*?"\s*\/?>/,
-        `<meta property="og:description" content="${description}">`
-      )
-      .replace(
-        /<meta property="og:image" content=".*?"\s*\/?>/,
-        `<meta property="og:image" content="${image}">`
-      )
-      .replace(
-        /<meta property="og:url" content=".*?"\s*\/?>/,
-        `<meta property="og:url" content="${eventUrl}">`
-      )
-      .replace(
-        /<meta property="og:type" content=".*?"\s*\/?>/,
-        `<meta property="og:type" content="article">`
-      )
-      // Twitter tags
-      .replace(
-        /<meta name="twitter:title" content=".*?"\s*\/?>/,
-        `<meta name="twitter:title" content="${title}">`
-      )
-      .replace(
-        /<meta name="twitter:description" content=".*?"\s*\/?>/,
-        `<meta name="twitter:description" content="${description}">`
-      )
-      .replace(
-        /<meta name="twitter:image" content=".*?"\s*\/?>/,
-        `<meta name="twitter:image" content="${image}">`
-      )
-      .replace(
-        /<meta name="twitter:url" content=".*?"\s*\/?>/,
-        `<meta name="twitter:url" content="${eventUrl}">`
-      );
-    
-    // Add event-specific structured data
-    const structuredData = {
-      "@context": "https://schema.org",
-      "@type": "Event",
-      "name": event.title,
-      "description": event.description || '',
-      "startDate": event.eventDate,
-      "endDate": event.endDate || event.eventDate,
-      "eventStatus": "https://schema.org/EventScheduled",
-      "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-      "location": {
-        "@type": "Place",
-        "name": event.location,
-        "address": event.location
-      },
-      "image": image,
-      "organizer": {
-        "@type": "Organization",
-        "name": "OutMeets",
-        "url": "https://www.outmeets.com"
-      },
-      "offers": event.price > 0 ? {
-        "@type": "Offer",
-        "price": event.price,
-        "priceCurrency": "GBP",
-        "availability": "https://schema.org/InStock",
-        "url": eventUrl
-      } : undefined
-    };
-    
-    // Inject structured data before </head>
-    // Replace '</' in JSON to prevent </script> injection breaking the document
-    const safeJsonLd = JSON.stringify(structuredData).replace(/</g, '\\u003c');
-    html = html.replace(
-      '</head>',
-      `<script type="application/ld+json">${safeJsonLd}</script></head>`
-    );
-    
+      .replace(/<title>.*?<\/title>/, `<title>${title}</title>`)
+      .replace(/<meta name="description" content=".*?"\s*\/?>/, `<meta name="description" content="${description}">`)
+      .replace(/<meta property="og:title" content=".*?"\s*\/?>/, `<meta property="og:title" content="${title}">`)
+      .replace(/<meta property="og:description" content=".*?"\s*\/?>/, `<meta property="og:description" content="${description}">`)
+      .replace(/<meta property="og:image" content=".*?"\s*\/?>/, `<meta property="og:image" content="${escapeHtml(image)}">`)
+      .replace(/<meta property="og:url" content=".*?"\s*\/?>/, `<meta property="og:url" content="${escapeHtml(eventUrl)}">`)
+      .replace(/<meta property="og:type" content=".*?"\s*\/?>/, `<meta property="og:type" content="article">`)
+      .replace(/<meta name="twitter:title" content=".*?"\s*\/?>/, `<meta name="twitter:title" content="${title}">`)
+      .replace(/<meta name="twitter:description" content=".*?"\s*\/?>/, `<meta name="twitter:description" content="${description}">`)
+      .replace(/<meta name="twitter:image" content=".*?"\s*\/?>/, `<meta name="twitter:image" content="${escapeHtml(image)}">`)
+      .replace(/<meta name="twitter:url" content=".*?"\s*\/?>/, `<meta name="twitter:url" content="${escapeHtml(eventUrl)}">`);
+
+    const canonicalTag = `<link rel="canonical" href="${escapeHtml(eventUrl)}" />`;
+    html = html.replace(/<link rel="canonical" href=".*?"\s*\/?>/, canonicalTag);
+
+    const safeJsonLd = JSON.stringify(schema).replace(/</g, '\\u003c');
+    html = html.replace('</head>', `<script type="application/ld+json">${safeJsonLd}</script></head>`);
+
     return new Response(html, {
       headers: {
         'content-type': 'text/html;charset=UTF-8',
-        'cache-control': 'public, max-age=300', // Cache for 5 minutes
+        'cache-control': 'public, max-age=300',
       },
     });
-    
   } catch (error) {
     console.error('Error fetching event data:', error);
     return context.next();
   }
+}
+
+const HIKING_GRADE_FAQ_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  'mainEntity': [
+    {
+      '@type': 'Question',
+      'name': 'What is a Beginner hiking grade?',
+      'acceptedAnswer': {
+        '@type': 'Answer',
+        'text': 'Beginner hikes are perfect for first-time hikers and families. Trails are well-maintained and clearly marked, with minimal elevation gain (under 300m) and distances typically under 8km. They usually take 2–3 hours and are suitable for most fitness levels.',
+      },
+    },
+    {
+      '@type': 'Question',
+      'name': 'What is an Intermediate hiking grade?',
+      'acceptedAnswer': {
+        '@type': 'Answer',
+        'text': 'Intermediate hikes are for hikers with some experience. They involve moderate elevation gain (300–600m), distances of 8–15km, and some steep sections on well-defined paths. Typically take 3–5 hours and require moderate fitness.',
+      },
+    },
+    {
+      '@type': 'Question',
+      'name': 'What is an Advanced hiking grade?',
+      'acceptedAnswer': {
+        '@type': 'Answer',
+        'text': 'Advanced hikes are challenging and for experienced hikers. They involve significant elevation gain (600–1000m), distances of 15–25km, steep climbs, and rocky terrain. They usually take 5–8 hours and require good fitness and stamina.',
+      },
+    },
+    {
+      '@type': 'Question',
+      'name': 'What is an Expert hiking grade?',
+      'acceptedAnswer': {
+        '@type': 'Answer',
+        'text': 'Expert hikes are very challenging and for highly experienced hikers only. They involve extreme elevation gain (over 1000m), distances often over 25km, technical terrain, scrambling, and can take 8+ hours. Excellent fitness and technical skills are required.',
+      },
+    },
+    {
+      '@type': 'Question',
+      'name': 'What equipment do I need for a day hike from London?',
+      'acceptedAnswer': {
+        '@type': 'Answer',
+        'text': 'For beginner hikes, comfortable walking shoes, 1L water, and light snacks are sufficient. For intermediate hikes, bring hiking boots, 2L water, packed lunch, and a weatherproof jacket. Advanced and Expert hikes require high-quality boots, 2–3L water, navigation tools, and comprehensive first aid.',
+      },
+    },
+  ],
+};
+
+const PACE_FAQ_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  'mainEntity': [
+    {
+      '@type': 'Question',
+      'name': 'What does Leisurely pace mean on a hike?',
+      'acceptedAnswer': {
+        '@type': 'Answer',
+        'text': 'Leisurely pace is approximately 2–3 km/h with frequent breaks, stops at viewpoints, and a social atmosphere. Ideal for first-time hikers, families, and anyone who prefers a relaxed, sociable day out.',
+      },
+    },
+    {
+      '@type': 'Question',
+      'name': 'What does Steady pace mean on a hike?',
+      'acceptedAnswer': {
+        '@type': 'Answer',
+        'text': 'Steady pace is approximately 3–4 km/h with breaks at summits and viewpoints. It balances covering ground with enjoying the route. Suitable for hikers with some regular walking experience.',
+      },
+    },
+    {
+      '@type': 'Question',
+      'name': 'What does Brisk pace mean on a hike?',
+      'acceptedAnswer': {
+        '@type': 'Answer',
+        'text': 'Brisk pace is approximately 4–5 km/h with shorter stops. It covers more ground and is suitable for those with good fitness who want a more energetic hike.',
+      },
+    },
+    {
+      '@type': 'Question',
+      'name': 'Which hiking pace is right for beginners in London?',
+      'acceptedAnswer': {
+        '@type': 'Answer',
+        'text': 'Leisurely or Steady pace is best for beginners joining day hike groups from London. These paces allow you to enjoy the scenery, socialise with the group, and not feel rushed or left behind.',
+      },
+    },
+  ],
+};
+
+const LONDON_DAY_HIKES_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  'name': 'Day Hikes from London | OutMeets',
+  'description': 'Find and join organised day hikes from London with local hiking groups. Explore the Surrey Hills, Chilterns, South Downs and more. All abilities welcome.',
+  'url': 'https://www.outmeets.com/london/day-hikes',
+  'about': {
+    '@type': 'SportsEvent',
+    'name': 'Day Hikes from London',
+    'location': {
+      '@type': 'Place',
+      'name': 'London, United Kingdom',
+      'geo': {
+        '@type': 'GeoCoordinates',
+        'latitude': '51.5074',
+        'longitude': '-0.1278',
+      },
+    },
+  },
+  'breadcrumb': {
+    '@type': 'BreadcrumbList',
+    'itemListElement': [
+      { '@type': 'ListItem', 'position': 1, 'name': 'Home', 'item': 'https://www.outmeets.com/' },
+      { '@type': 'ListItem', 'position': 2, 'name': 'Day Hikes from London', 'item': 'https://www.outmeets.com/london/day-hikes' },
+    ],
+  },
+};
+
+export default async (request, context) => {
+  const url = new URL(request.url);
+  const pathname = url.pathname;
+
+  const userAgent = request.headers.get('user-agent') || '';
+  if (!isCrawlerRequest(userAgent)) {
+    return context.next();
+  }
+
+  // Event detail pages — dynamic meta from API
+  const eventMatch = pathname.match(/^\/events\/(\d+)$/);
+  if (eventMatch) {
+    return handleEventPage(request, context, eventMatch[1]);
+  }
+
+  // Hiking grade FAQ page
+  if (pathname === '/hiking-grade-faq') {
+    return injectMetaTags(context, {
+      title: 'Hiking Difficulty Grades Explained | OutMeets',
+      description: 'Understand hiking difficulty grades: Beginner, Intermediate, Advanced, Expert. Learn trail characteristics and what equipment to bring for day hikes from London.',
+      url: 'https://www.outmeets.com/hiking-grade-faq',
+      schema: HIKING_GRADE_FAQ_SCHEMA,
+    });
+  }
+
+  // Pace FAQ page
+  if (pathname === '/pace-faq') {
+    return injectMetaTags(context, {
+      title: 'Hiking Pace Guide — Leisurely to Brisk | OutMeets',
+      description: 'Understand hiking pace levels used in OutMeets events: Leisurely, Steady, and Brisk. Find the right pace for your fitness level on day hikes from London.',
+      url: 'https://www.outmeets.com/pace-faq',
+      schema: PACE_FAQ_SCHEMA,
+    });
+  }
+
+  // London day hikes landing page
+  if (pathname === '/london/day-hikes') {
+    return injectMetaTags(context, {
+      title: 'Day Hikes from London | Join Hiking Groups | OutMeets',
+      description: 'Discover and join organised day hikes from London with local hiking groups. Surrey Hills, Chilterns, South Downs and more. All abilities welcome on OutMeets.',
+      url: 'https://www.outmeets.com/london/day-hikes',
+      schema: LONDON_DAY_HIKES_SCHEMA,
+    });
+  }
+
+  return context.next();
 };
 
 export const config = {
-  path: "/events/*"
+  path: "/*",
 };

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -1,0 +1,43 @@
+# OutMeets
+
+OutMeets is an online platform for discovering and joining organised day hikes from London with local hiking groups.
+
+## What OutMeets does
+
+OutMeets connects hikers in and around London with organised group hiking events led by experienced local guides and group organisers. Events run to popular hiking areas reachable by train from London, including:
+
+- Surrey Hills (Area of Outstanding Natural Beauty)
+- Chilterns (rolling chalk hills and ancient beechwood)
+- South Downs National Park (open downland and coastal cliffs)
+- North Downs Way (National Trail through Surrey and Kent)
+- Other scenic trails within 1–2 hours of London
+
+## Who uses OutMeets
+
+- People looking to join day hike groups from London
+- Hikers who want to explore trails near London with a social group
+- Beginners wanting guided, welcoming hikes in the London area
+- Experienced hikers looking for organised advanced or long-distance routes
+- Hiking group organisers running events across South East England
+
+## Key features
+
+- Browse upcoming day hikes from London by date, difficulty, and location
+- Join existing hiking groups based in and around London
+- Events graded Beginner, Intermediate, Advanced, or Expert
+- Hike pace levels: Leisurely, Steady, Brisk
+- Events organised and led by experienced group organisers
+- Community-based platform — not a commercial tour operator
+
+## Key pages
+
+- https://www.outmeets.com/ — Homepage and event discovery
+- https://www.outmeets.com/london/day-hikes — Day hikes from London guide
+- https://www.outmeets.com/events — Browse all upcoming hikes
+- https://www.outmeets.com/groups — Browse hiking groups
+- https://www.outmeets.com/hiking-grade-faq — Hiking difficulty grade guide
+- https://www.outmeets.com/pace-faq — Hiking pace level guide
+
+## Contact
+
+Website: https://www.outmeets.com

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,14 @@
+User-agent: *
+Allow: /
+Disallow: /admin
+Disallow: /profile
+Disallow: /settings
+Disallow: /notifications
+Disallow: /create-event
+Disallow: /events/*/edit
+Disallow: /groups/*/edit
+Disallow: /groups/create
+Disallow: /groups/*/transfer
+Disallow: /auth/
+
+Sitemap: https://www.outmeets.com/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+  <url>
+    <loc>https://www.outmeets.com/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+  <url>
+    <loc>https://www.outmeets.com/london/day-hikes</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://www.outmeets.com/events</loc>
+    <changefreq>hourly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://www.outmeets.com/groups</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://www.outmeets.com/hiking-grade-faq</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://www.outmeets.com/pace-faq</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+</urlset>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,6 +36,7 @@ const ReviewSubmissionPage = lazy(() => import('./pages/ReviewSubmissionPage'))
 const GroupReviewsPage = lazy(() => import('./pages/GroupReviewsPage'))
 const EventReviewsPage = lazy(() => import('./pages/EventReviewsPage'))
 const MyReviewsPage = lazy(() => import('./pages/MyReviewsPage'))
+const LondonDayHikesPage = lazy(() => import('./pages/LondonDayHikesPage'))
 
 // Loading fallback component
 function PageLoader() {
@@ -81,6 +82,7 @@ const PAGE_NAMES = {
   '/settings': 'Settings',
   '/notifications': 'Notifications',
   '/admin': 'Admin',
+  '/london/day-hikes': 'London Day Hikes',
   '/hiking-grade-faq': 'Hiking Grade FAQ',
   '/pace-faq': 'Pace FAQ',
   '/auth/verify': 'Verify Magic Link',
@@ -253,6 +255,11 @@ function App() {
         <Route path="groups" element={
           <Suspense fallback={<PageLoader />}>
             <BrowseGroupsPage />
+          </Suspense>
+        } />
+        <Route path="london/day-hikes" element={
+          <Suspense fallback={<PageLoader />}>
+            <LondonDayHikesPage />
           </Suspense>
         } />
         <Route path="hiking-grade-faq" element={

--- a/frontend/src/pages/LondonDayHikesPage.jsx
+++ b/frontend/src/pages/LondonDayHikesPage.jsx
@@ -1,0 +1,236 @@
+import { useNavigate } from 'react-router-dom'
+import { Mountain, Users, MapPin, ArrowRight, ChevronRight } from 'lucide-react'
+
+const HIKING_AREAS = [
+  {
+    name: 'Surrey Hills',
+    description: 'An Area of Outstanding Natural Beauty just 30–50 minutes from London. Box Hill, Leith Hill, and Holmbury Hill offer sweeping views across the Weald with well-marked trails for all abilities.',
+    travelTime: '~35 min from London Bridge',
+    grade: 'Beginner to Advanced',
+  },
+  {
+    name: 'Chilterns',
+    description: 'Rolling chalk hills with ancient beech woodland stretching from the Thames Valley to Luton. Classic routes include the Ridgeway, Ivinghoe Beacon, and the Hambleden Valley.',
+    travelTime: '~45 min from Marylebone',
+    grade: 'Beginner to Intermediate',
+  },
+  {
+    name: 'South Downs',
+    description: 'England\'s newest National Park, with open downland, dramatic coastal cliffs, and the iconic Seven Sisters. Excellent long-distance routes from Eastbourne to Winchester.',
+    travelTime: '~1 hr from Victoria',
+    grade: 'Intermediate to Advanced',
+  },
+  {
+    name: 'North Downs Way',
+    description: 'A 246-km National Trail running through Kent and Surrey. Day sections from Farnham to Guildford or along the Pilgrim\'s Way offer varied terrain close to London.',
+    travelTime: '~40 min from Waterloo',
+    grade: 'Beginner to Intermediate',
+  },
+]
+
+const HOW_IT_WORKS = [
+  {
+    step: '1',
+    title: 'Browse upcoming hikes',
+    description: 'Find day hikes organised by local hiking groups, filtered by date, difficulty, and location.',
+  },
+  {
+    step: '2',
+    title: 'Join the event',
+    description: 'Sign up with one tap. The organiser confirms your spot and shares meeting point details.',
+  },
+  {
+    step: '3',
+    title: 'Meet and hike',
+    description: 'Meet at the trailhead, hike with the group, and discover great trails near London.',
+  },
+]
+
+const DIFFICULTY_SUMMARY = [
+  { label: 'Beginner', icon: '🟢', desc: 'Under 8km, flat to gentle. Perfect for first-timers.' },
+  { label: 'Intermediate', icon: '🟡', desc: '8–15km, moderate ascents. Some hiking experience helpful.' },
+  { label: 'Advanced', icon: '🟠', desc: '15–25km, significant climbs. Good fitness required.' },
+]
+
+export default function LondonDayHikesPage() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-purple-50/30 to-pink-50/30">
+
+      {/* Hero */}
+      <div className="bg-gradient-to-br from-purple-600 via-pink-600 to-orange-500 text-white">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-14 sm:py-20">
+          <nav className="text-sm mb-6 text-white/70">
+            <button onClick={() => navigate('/')} className="hover:text-white transition-colors">Home</button>
+            <ChevronRight className="inline h-3 w-3 mx-1" />
+            <span className="text-white">Day Hikes from London</span>
+          </nav>
+          <div className="flex items-start gap-4 mb-6">
+            <Mountain className="h-10 w-10 sm:h-12 sm:w-12 flex-shrink-0 mt-1" />
+            <div>
+              <h1 className="text-3xl sm:text-5xl font-extrabold leading-tight mb-4">
+                Day Hikes from London
+              </h1>
+              <p className="text-lg sm:text-xl text-white/90 max-w-2xl">
+                Join organised hiking groups exploring the best trails within two hours of London.
+                Surrey Hills, Chilterns, South Downs, and more — all abilities welcome.
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={() => navigate('/events')}
+            className="inline-flex items-center gap-2 bg-white text-purple-700 font-bold px-6 py-3 rounded-xl hover:bg-purple-50 transition-colors text-sm sm:text-base"
+          >
+            Browse upcoming hikes
+            <ArrowRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-16 space-y-14 sm:space-y-20">
+
+        {/* What is OutMeets */}
+        <section>
+          <h2 className="text-2xl sm:text-3xl font-extrabold text-gray-900 mb-4">
+            Hiking groups for day hikes from London
+          </h2>
+          <div className="prose prose-gray max-w-none text-gray-600 space-y-4 text-base sm:text-lg">
+            <p>
+              OutMeets is a platform for finding and joining organised day hikes from London.
+              Local hiking groups post upcoming events — you browse by date, difficulty, and destination,
+              then join the ones that suit you.
+            </p>
+            <p>
+              Whether you&apos;re new to hiking and looking for a welcoming beginner group, or an
+              experienced hiker wanting to tackle a long-distance challenge, there&apos;s a hike for you.
+              All events are led by experienced group organisers who know the routes and keep the group together.
+            </p>
+            <p>
+              Groups typically depart from a London train station or directly from a trailhead car park,
+              making it easy to reach great hiking countryside without a car.
+            </p>
+          </div>
+        </section>
+
+        {/* Hiking Areas */}
+        <section>
+          <h2 className="text-2xl sm:text-3xl font-extrabold text-gray-900 mb-2">
+            Popular hiking areas from London
+          </h2>
+          <p className="text-gray-500 mb-8 text-base sm:text-lg">
+            The best walking countryside is within an hour by train from central London.
+          </p>
+          <div className="grid sm:grid-cols-2 gap-5">
+            {HIKING_AREAS.map((area) => (
+              <div key={area.name} className="bg-white rounded-2xl p-5 sm:p-6 shadow-sm border border-purple-100 hover:shadow-md transition-shadow">
+                <div className="flex items-start gap-3 mb-3">
+                  <MapPin className="h-5 w-5 text-purple-500 flex-shrink-0 mt-0.5" />
+                  <div>
+                    <h3 className="font-bold text-gray-900 text-lg">{area.name}</h3>
+                    <p className="text-xs text-purple-600 font-medium">{area.travelTime}</p>
+                  </div>
+                </div>
+                <p className="text-gray-600 text-sm leading-relaxed mb-3">{area.description}</p>
+                <span className="inline-block text-xs font-semibold bg-purple-50 text-purple-700 px-3 py-1 rounded-full">
+                  {area.grade}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Difficulty levels */}
+        <section>
+          <h2 className="text-2xl sm:text-3xl font-extrabold text-gray-900 mb-2">
+            Hikes for every ability level
+          </h2>
+          <p className="text-gray-500 mb-7 text-base sm:text-lg">
+            Every event is graded so you know exactly what to expect before you sign up.
+          </p>
+          <div className="grid sm:grid-cols-3 gap-4 mb-5">
+            {DIFFICULTY_SUMMARY.map((level) => (
+              <div key={level.label} className="bg-white rounded-xl p-4 shadow-sm border border-gray-100 text-center">
+                <div className="text-3xl mb-2">{level.icon}</div>
+                <p className="font-bold text-gray-900 mb-1">{level.label}</p>
+                <p className="text-xs text-gray-500">{level.desc}</p>
+              </div>
+            ))}
+          </div>
+          <button
+            onClick={() => navigate('/hiking-grade-faq')}
+            className="text-sm text-purple-600 font-semibold hover:text-purple-800 transition-colors flex items-center gap-1"
+          >
+            Full difficulty grade guide
+            <ArrowRight className="h-4 w-4" />
+          </button>
+        </section>
+
+        {/* How it works */}
+        <section>
+          <h2 className="text-2xl sm:text-3xl font-extrabold text-gray-900 mb-8">
+            How to join a hiking group from London
+          </h2>
+          <div className="grid sm:grid-cols-3 gap-6">
+            {HOW_IT_WORKS.map((item) => (
+              <div key={item.step} className="flex gap-4">
+                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 text-white font-extrabold flex items-center justify-center text-lg">
+                  {item.step}
+                </div>
+                <div>
+                  <h3 className="font-bold text-gray-900 mb-1">{item.title}</h3>
+                  <p className="text-gray-500 text-sm leading-relaxed">{item.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Why join a group */}
+        <section className="bg-white rounded-2xl p-6 sm:p-8 shadow-sm border border-purple-100">
+          <div className="flex items-start gap-4">
+            <Users className="h-8 w-8 text-purple-500 flex-shrink-0 mt-1" />
+            <div>
+              <h2 className="text-xl sm:text-2xl font-extrabold text-gray-900 mb-3">
+                Why hike with a group?
+              </h2>
+              <ul className="space-y-2 text-gray-600 text-sm sm:text-base">
+                <li className="flex items-start gap-2"><span className="text-purple-500 font-bold mt-0.5">•</span> Safer and more enjoyable than hiking alone on unfamiliar trails</li>
+                <li className="flex items-start gap-2"><span className="text-purple-500 font-bold mt-0.5">•</span> Routes are planned and led by experienced organisers who know the terrain</li>
+                <li className="flex items-start gap-2"><span className="text-purple-500 font-bold mt-0.5">•</span> Meet other hikers in London and make friends who share the same interests</li>
+                <li className="flex items-start gap-2"><span className="text-purple-500 font-bold mt-0.5">•</span> No need to plan anything yourself — just show up and hike</li>
+                <li className="flex items-start gap-2"><span className="text-purple-500 font-bold mt-0.5">•</span> Consistent pace kept so the group stays together throughout</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="text-center py-4">
+          <h2 className="text-2xl sm:text-3xl font-extrabold text-gray-900 mb-3">
+            Ready to find your next day hike from London?
+          </h2>
+          <p className="text-gray-500 mb-7 text-base sm:text-lg max-w-xl mx-auto">
+            Browse upcoming hikes, pick one that suits you, and join in minutes.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <button
+              onClick={() => navigate('/events')}
+              className="inline-flex items-center justify-center gap-2 bg-gradient-to-r from-purple-600 to-pink-600 text-white font-bold px-8 py-3.5 rounded-xl hover:opacity-90 transition-opacity text-base"
+            >
+              Browse upcoming hikes
+              <ArrowRight className="h-5 w-5" />
+            </button>
+            <button
+              onClick={() => navigate('/groups')}
+              className="inline-flex items-center justify-center gap-2 bg-white border-2 border-purple-200 text-purple-700 font-bold px-8 py-3.5 rounded-xl hover:bg-purple-50 transition-colors text-base"
+            >
+              Explore hiking groups
+            </button>
+          </div>
+        </section>
+
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- Extend Netlify edge function to pre-render for Googlebot, Bingbot and all
  search engine crawlers (previously social bots only); register on /* instead
  of /events/* so FAQ and content pages also get proper meta tags injected
- Add FAQPage JSON-LD schema for /hiking-grade-faq and /pace-faq
- Add robots.txt with correct allow/disallow rules and sitemap pointer
- Add sitemap.xml with all public static pages and priority/changefreq hints
- Add /london/day-hikes static content page targeting "day hike london" query
  with hiking area descriptions, how-it-works, CTAs, and breadcrumb schema
- Add llms.txt for LLM crawler context (Perplexity, Claude, etc.)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
