### PR TITLE
fix: update production deployment URL to actual Render service URL

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -208,7 +208,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     environment:
       name: production
-      url: https://api.outmeets.com
+      url: https://organiser-platform.onrender.com
     
     steps:
       - name: Checkout code
@@ -230,7 +230,7 @@ jobs:
       - name: Notify deployment
         run: |
           echo "✅ Production backend deployed!"
-          echo "API URL: https://api.outmeets.com"
+          echo "API URL: https://organiser-platform.onrender.com"
           echo "Commit: ${{ github.sha }}"
 
   health-check:


### PR DESCRIPTION
## Summary
- Replaces the non-existent `https://api.outmeets.com` custom domain with the actual Render service URL `https://organiser-platform.onrender.com` in the GitHub deployment environment config
- Fixes the broken link shown on the GitHub Actions "Last deployed" badge for the production environment

## Test plan
- [ ] Merge to staging, then verify the GitHub Actions production environment shows the correct clickable URL after the next deploy to `main`