### PR TITLE
chore: zip CI artifacts before upload to reduce file count

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -63,20 +63,28 @@ jobs:
         working-directory: backend
         run: ./gradlew jacocoTestReport
 
+      - name: Zip test results
+        if: always()
+        run: zip -r test-results.zip backend/build/reports/tests/test/
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: backend/build/reports/tests/test/
+          path: test-results.zip
           retention-days: 7
+
+      - name: Zip coverage report
+        if: always()
+        run: zip -r coverage-report.zip backend/build/reports/jacoco/test/
 
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
-          path: backend/build/reports/jacoco/test/
+          path: coverage-report.zip
           retention-days: 7
 
       - name: Check test coverage


### PR DESCRIPTION
## Summary
- Zip test results and JaCoCo coverage report before uploading as GitHub Actions artifacts
- Reduces artifact file count from ~353 files → 1 zip file per upload, avoiding storage quota issues

## Test plan
- [ ] Trigger a backend CI run and verify both `test-results.zip` and `coverage-report.zip` appear as artifacts
- [ ] Confirm artifacts are downloadable and contain the expected HTML reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)