### PR TITLE
fix: persist review prompt dismissals to the database

### DIFF
--- a/backend/src/main/java/com/organiser/platform/config/SecurityConfig.java
+++ b/backend/src/main/java/com/organiser/platform/config/SecurityConfig.java
@@ -142,7 +142,8 @@ public class SecurityConfig {
                                 new AntPathRequestMatcher("/api/v1/reviews/*", "DELETE"),
                                 new AntPathRequestMatcher("/api/v1/reviews/pending", "GET"),
                                 new AntPathRequestMatcher("/api/v1/reviews/my-reviews", "GET"),
-                                new AntPathRequestMatcher("/api/v1/reviews/*/flag", "POST")
+                                new AntPathRequestMatcher("/api/v1/reviews/*/flag", "POST"),
+                                new AntPathRequestMatcher("/api/v1/reviews/dismiss/*", "POST")
                         ).authenticated()
                         
                         // Group write operations - require authentication

--- a/backend/src/main/java/com/organiser/platform/controller/ReviewController.java
+++ b/backend/src/main/java/com/organiser/platform/controller/ReviewController.java
@@ -24,6 +24,12 @@ public class ReviewController {
         return ResponseEntity.ok(reviewService.getPendingReviews());
     }
 
+    @PostMapping("/reviews/dismiss/{eventId}")
+    public ResponseEntity<Void> dismissReviewPrompt(@PathVariable Long eventId) {
+        reviewService.dismissReviewPrompt(eventId);
+        return ResponseEntity.noContent().build();
+    }
+
     @GetMapping("/reviews/my-reviews")
     public ResponseEntity<Page<EventReviewDTO>> getMyReviews(
             @RequestParam(defaultValue = "0") int page,

--- a/backend/src/main/java/com/organiser/platform/model/EventParticipant.java
+++ b/backend/src/main/java/com/organiser/platform/model/EventParticipant.java
@@ -10,6 +10,7 @@ import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 /**
@@ -80,6 +81,9 @@ public class EventParticipant {
     @Column(name = "review_prompt_sent", nullable = false)
     @Builder.Default
     private Boolean reviewPromptSent = false;
+
+    @Column(name = "review_prompt_dismissed_at")
+    private Instant reviewPromptDismissedAt;
     
     public enum ParticipationStatus {
         REGISTERED,

--- a/backend/src/main/java/com/organiser/platform/repository/EventParticipantRepository.java
+++ b/backend/src/main/java/com/organiser/platform/repository/EventParticipantRepository.java
@@ -56,6 +56,7 @@ public interface EventParticipantRepository extends JpaRepository<EventParticipa
         JOIN FETCH e.group g
         JOIN FETCH g.primaryOrganiser
         WHERE ep.reviewPromptSent = false
+          AND ep.reviewPromptDismissedAt IS NULL
           AND ep.status IN ('REGISTERED', 'CONFIRMED', 'ATTENDED')
           AND e.eventDate BETWEEN :windowStart AND :windowEnd
           AND NOT EXISTS (

--- a/backend/src/main/java/com/organiser/platform/service/ReviewService.java
+++ b/backend/src/main/java/com/organiser/platform/service/ReviewService.java
@@ -89,6 +89,22 @@ public class ReviewService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
+    public void dismissReviewPrompt(Long eventId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Member not found"));
+
+        EventParticipant ep = eventParticipantRepository
+                .findByEventIdAndMemberId(eventId, member.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Participation not found"));
+
+        ep.setReviewPromptDismissedAt(Instant.now());
+        eventParticipantRepository.save(ep);
+    }
+
     public Page<EventReviewDTO> getMyReviews(int page, int size) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();

--- a/backend/src/main/resources/db/migration/postgresql/V54__add_review_prompt_dismissed_at_to_event_participants.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V54__add_review_prompt_dismissed_at_to_event_participants.sql
@@ -1,0 +1,2 @@
+ALTER TABLE event_participants
+    ADD COLUMN review_prompt_dismissed_at TIMESTAMP WITH TIME ZONE;

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -449,6 +449,9 @@ export const reviewsAPI = {
   // Get pending reviews for current user
   getPendingReviews: () => api.get('/reviews/pending'),
 
+  // Dismiss a review prompt so it never shows again
+  dismissReviewPrompt: (eventId) => api.post(`/reviews/dismiss/${eventId}`),
+
   // Get all reviews submitted by the current user
   getMyReviews: (page = 0, size = 20) => api.get(`/reviews/my-reviews?page=${page}&size=${size}`),
   

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -100,10 +100,13 @@ export default function HomePage() {
   const pendingReviews = (pendingReviewsData || []).filter(r => !optimisticallyDismissed.includes(r.eventId))
 
   const dismissReview = useCallback((eventId) => {
-    setOptimisticallyDismissed(prev => [...prev, eventId])
-    reviewsAPI.dismissReviewPrompt(eventId)
-      .then(() => queryClient.invalidateQueries({ queryKey: ['pendingReviews'] }))
-      .catch(() => setOptimisticallyDismissed(prev => prev.filter(id => id !== eventId)))
+    setOptimisticallyDismissed(prev => {
+      if (prev.includes(eventId)) return prev
+      reviewsAPI.dismissReviewPrompt(eventId)
+        .then(() => queryClient.invalidateQueries({ queryKey: ['pendingReviews'] }))
+        .catch(() => setOptimisticallyDismissed(ids => ids.filter(id => id !== eventId)))
+      return [...prev, eventId]
+    })
   }, [queryClient])
 
   const { data: featureFlags, isLoading: featureFlagsLoading } = useQuery({

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,9 +1,9 @@
 // ============================================================
 // IMPORTS
 // ============================================================
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Search, Lock, Star, X } from 'lucide-react'
 import { groupsAPI, eventsAPI, featureFlagsAPI, reviewsAPI } from '../lib/api'
 import { useAuthStore } from '../store/authStore'
@@ -30,6 +30,7 @@ export default function HomePage() {
   // ============================================================
   const navigate = useNavigate()
   const { isAuthenticated, user } = useAuthStore()  // Global auth state
+  const queryClient = useQueryClient()
   
   // ============================================================
   // LOCAL STATE
@@ -37,9 +38,7 @@ export default function HomePage() {
   const [activeGroupTab, setActiveGroupTab] = useState('member')  // Tab selection: 'member' or 'organiser'
   const [hasInitializedTab, setHasInitializedTab] = useState(false)  // Track if tab has been auto-selected
   const [loginModalOpen, setLoginModalOpen] = useState(false)  // Login modal state
-  const [dismissedReviews, setDismissedReviews] = useState(() => {
-    try { return JSON.parse(localStorage.getItem('dismissed-review-prompts') || '[]') } catch { return [] }
-  })
+  const [optimisticallyDismissed, setOptimisticallyDismissed] = useState([])
   
   // Check if user has already clicked discover before (localStorage)
   const [showDiscover, setShowDiscover] = useState(() => {
@@ -98,13 +97,14 @@ export default function HomePage() {
     staleTime: 5 * 60 * 1000,
   })
 
-  const pendingReviews = (pendingReviewsData || []).filter(r => !dismissedReviews.includes(r.eventId))
+  const pendingReviews = (pendingReviewsData || []).filter(r => !optimisticallyDismissed.includes(r.eventId))
 
-  const dismissReview = (eventId) => {
-    const updated = [...dismissedReviews, eventId]
-    setDismissedReviews(updated)
-    try { localStorage.setItem('dismissed-review-prompts', JSON.stringify(updated)) } catch {}
-  }
+  const dismissReview = useCallback((eventId) => {
+    setOptimisticallyDismissed(prev => [...prev, eventId])
+    reviewsAPI.dismissReviewPrompt(eventId)
+      .then(() => queryClient.invalidateQueries({ queryKey: ['pendingReviews'] }))
+      .catch(() => setOptimisticallyDismissed(prev => prev.filter(id => id !== eventId)))
+  }, [queryClient])
 
   const { data: featureFlags, isLoading: featureFlagsLoading } = useQuery({
     queryKey: ['featureFlags'],


### PR DESCRIPTION
## Summary

- Review prompt dismissals were previously stored in `localStorage`, causing them to reappear after clearing browser data or on a different device/browser
- Adds a `review_prompt_dismissed_at` column to `event_participants` so the dismissal is stored server-side and is permanent
- Frontend uses optimistic UI update (hides immediately on click) with rollback if the API call fails

## Changes

**Backend**
- `V54` migration: adds `review_prompt_dismissed_at TIMESTAMP WITH TIME ZONE` to `event_participants`
- `EventParticipant`: new `reviewPromptDismissedAt` field
- `EventParticipantRepository`: JPQL query now excludes dismissed rows (`ep.reviewPromptDismissedAt IS NULL`)
- `ReviewService`: new `dismissReviewPrompt(eventId)` method
- `ReviewController`: new `POST /reviews/dismiss/{eventId}` endpoint
- `SecurityConfig`: endpoint registered as authenticated

**Frontend**
- `api.js`: `reviewsAPI.dismissReviewPrompt(eventId)`
- `HomePage.jsx`: calls dismiss API on X click, with optimistic update + error rollback; removes old localStorage approach

## Test plan

- [ ] Dismiss a review prompt card — it should disappear immediately
- [ ] Reload the page — it should not reappear
- [ ] Clear browser data and reload — it should still not reappear
- [ ] Verify backend: `event_participants.review_prompt_dismissed_at` is set for the dismissed row

🤖 Generated with [Claude Code](https://claude.com/claude-code)