### PR TITLE
feat: show group name and group rating on event card

### DIFF
--- a/backend/src/main/java/com/organiser/platform/dto/EventDTO.java
+++ b/backend/src/main/java/com/organiser/platform/dto/EventDTO.java
@@ -54,6 +54,8 @@ public class EventDTO {
     private String cancellationPolicy;
     private BigDecimal averageRating;
     private Integer totalReviews;
+    private BigDecimal groupAverageRating;
+    private Integer groupTotalReviews;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Set<Long> participantIds;

--- a/backend/src/main/java/com/organiser/platform/repository/GroupRatingSummaryRepository.java
+++ b/backend/src/main/java/com/organiser/platform/repository/GroupRatingSummaryRepository.java
@@ -4,9 +4,12 @@ import com.organiser.platform.model.GroupRatingSummary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface GroupRatingSummaryRepository extends JpaRepository<GroupRatingSummary, Long> {
     Optional<GroupRatingSummary> findByGroupId(Long groupId);
+    List<GroupRatingSummary> findByGroupIdIn(Collection<Long> groupIds);
 }

--- a/backend/src/main/java/com/organiser/platform/service/EventService.java
+++ b/backend/src/main/java/com/organiser/platform/service/EventService.java
@@ -63,6 +63,7 @@ public class EventService {
     private final EventTransportLegRepository eventTransportLegRepository;
     private final WebPushService webPushService;
     private final EmailService emailService;
+    private final GroupRatingSummaryRepository groupRatingSummaryRepository;
     
     // ============================================================
     // PUBLIC METHODS - Event CRUD Operations
@@ -847,14 +848,16 @@ public class EventService {
                         ? event.getHostMember().getDisplayName()
                         : event.getHostMember().getEmail());
         }
-        
+
+        GroupRatingSummary groupRating = groupRatingSummaryRepository.findByGroupId(group.getId()).orElse(null);
+
         return EventDTO.builder()
                 .id(event.getId())
                 .title(event.getTitle())
                 .description(event.getDescription())
                 .organiserId(primaryOrganiser.getId())
-                .organiserName(primaryOrganiser.getDisplayName() != null && !primaryOrganiser.getDisplayName().isEmpty() 
-                        ? primaryOrganiser.getDisplayName() 
+                .organiserName(primaryOrganiser.getDisplayName() != null && !primaryOrganiser.getDisplayName().isEmpty()
+                        ? primaryOrganiser.getDisplayName()
                         : primaryOrganiser.getEmail())
                 .activityTypeId(activity.getId())
                 .activityTypeName(activity.getName())
@@ -891,6 +894,8 @@ public class EventService {
                 .cancellationPolicy(event.getCancellationPolicy())
                 .averageRating(event.getAverageRating() != null ? new BigDecimal(event.getAverageRating()) : BigDecimal.ZERO)
                 .totalReviews(event.getTotalReviews() != null ? event.getTotalReviews() : 0)
+                .groupAverageRating(groupRating != null && groupRating.getAverageRating() != null ? new BigDecimal(groupRating.getAverageRating()) : null)
+                .groupTotalReviews(groupRating != null ? groupRating.getTotalReviews() : 0)
                 .createdAt(event.getCreatedAt())
                 .updatedAt(event.getUpdatedAt())
                 .userIsGroupMember(true) // Default true for backward compatibility
@@ -953,14 +958,16 @@ public class EventService {
                         ? event.getHostMember().getDisplayName()
                         : event.getHostMember().getEmail());
         }
-        
+
+        GroupRatingSummary groupRating = groupRatingSummaryRepository.findByGroupId(group.getId()).orElse(null);
+
         return EventDTO.builder()
                 .id(event.getId())
                 .title(event.getTitle())
                 .description(event.getDescription())
                 .organiserId(primaryOrganiser.getId())
-                .organiserName(primaryOrganiser.getDisplayName() != null && !primaryOrganiser.getDisplayName().isEmpty() 
-                        ? primaryOrganiser.getDisplayName() 
+                .organiserName(primaryOrganiser.getDisplayName() != null && !primaryOrganiser.getDisplayName().isEmpty()
+                        ? primaryOrganiser.getDisplayName()
                         : primaryOrganiser.getEmail())
                 .activityTypeId(activity.getId())
                 .activityTypeName(activity.getName())
@@ -997,6 +1004,8 @@ public class EventService {
                 .cancellationPolicy(event.getCancellationPolicy())
                 .averageRating(event.getAverageRating() != null ? new BigDecimal(event.getAverageRating()) : BigDecimal.ZERO)
                 .totalReviews(event.getTotalReviews() != null ? event.getTotalReviews() : 0)
+                .groupAverageRating(groupRating != null && groupRating.getAverageRating() != null ? new BigDecimal(groupRating.getAverageRating()) : null)
+                .groupTotalReviews(groupRating != null ? groupRating.getTotalReviews() : 0)
                 .createdAt(event.getCreatedAt())
                 .updatedAt(event.getUpdatedAt())
                 .userIsGroupMember(isGroupMember)
@@ -1033,13 +1042,15 @@ public class EventService {
             throw new IllegalStateException("Group must be associated with an activity");
         }
         
+        GroupRatingSummary groupRating = groupRatingSummaryRepository.findByGroupId(group.getId()).orElse(null);
+
         // Return DTO with only basic information - no sensitive details
         return EventDTO.builder()
                 .id(event.getId())
                 .title(event.getTitle())
                 .organiserId(primaryOrganiser.getId())
-                .organiserName(primaryOrganiser.getDisplayName() != null && !primaryOrganiser.getDisplayName().isEmpty() 
-                        ? primaryOrganiser.getDisplayName() 
+                .organiserName(primaryOrganiser.getDisplayName() != null && !primaryOrganiser.getDisplayName().isEmpty()
+                        ? primaryOrganiser.getDisplayName()
                         : primaryOrganiser.getEmail())
                 .activityTypeId(activity.getId())
                 .activityTypeName(activity.getName())
@@ -1073,6 +1084,8 @@ public class EventService {
                 .cancellationPolicy(null)
                 .averageRating(BigDecimal.ZERO)
                 .totalReviews(0)
+                .groupAverageRating(groupRating != null && groupRating.getAverageRating() != null ? new BigDecimal(groupRating.getAverageRating()) : null)
+                .groupTotalReviews(groupRating != null ? groupRating.getTotalReviews() : 0)
                 .updatedAt(null)
                 .userIsGroupMember(false)
                 .groupIsPublic(group.getIsPublic())

--- a/backend/src/main/java/com/organiser/platform/service/EventService.java
+++ b/backend/src/main/java/com/organiser/platform/service/EventService.java
@@ -14,8 +14,10 @@ import com.organiser.platform.repository.*;
 import com.organiser.platform.util.EventTimingUtils;
 
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -310,8 +312,9 @@ public class EventService {
     @Transactional(readOnly = true)
     @Cacheable(value = "upcomingEvents", key = "#pageable.pageNumber + '-' + #pageable.pageSize")
     public Page<EventDTO> getUpcomingEvents(Pageable pageable) {
-        return eventRepository.findUpcomingEvents(Instant.now(), EventTimingUtils.startOfToday(), pageable)
-                .map(this::convertToDTO);
+        Page<Event> page = eventRepository.findUpcomingEvents(Instant.now(), EventTimingUtils.startOfToday(), pageable);
+        Map<Long, GroupRatingSummary> ratingsMap = buildRatingsMap(page.getContent());
+        return page.map(event -> convertToDTO(event, ratingsMap.get(event.getGroup().getId())));
     }
     
     // ============================================================
@@ -323,9 +326,10 @@ public class EventService {
      */
     @Transactional(readOnly = true)
     public Page<EventDTO> getEventsByActivity(Long activityId, Pageable pageable) {
-        return eventRepository.findUpcomingEventsByActivityId(
-                Instant.now(), EventTimingUtils.startOfToday(), activityId, pageable
-        ).map(this::convertToDTO);
+        Page<Event> page = eventRepository.findUpcomingEventsByActivityId(
+                Instant.now(), EventTimingUtils.startOfToday(), activityId, pageable);
+        Map<Long, GroupRatingSummary> ratingsMap = buildRatingsMap(page.getContent());
+        return page.map(event -> convertToDTO(event, ratingsMap.get(event.getGroup().getId())));
     }
     
     /**
@@ -333,8 +337,9 @@ public class EventService {
      */
     @Transactional(readOnly = true)
     public Page<EventDTO> searchEvents(String keyword, Pageable pageable) {
-        return eventRepository.searchEvents(keyword, Instant.now(), EventTimingUtils.startOfToday(), pageable)
-                .map(this::convertToDTO);
+        Page<Event> page = eventRepository.searchEvents(keyword, Instant.now(), EventTimingUtils.startOfToday(), pageable);
+        Map<Long, GroupRatingSummary> ratingsMap = buildRatingsMap(page.getContent());
+        return page.map(event -> convertToDTO(event, ratingsMap.get(event.getGroup().getId())));
     }
 
     /**
@@ -357,7 +362,8 @@ public class EventService {
                 pageable
         );
 
-        return results.map(this::convertToDTO);
+        Map<Long, GroupRatingSummary> ratingsMap = buildRatingsMap(results.getContent());
+        return results.map(event -> convertToDTO(event, ratingsMap.get(event.getGroup().getId())));
     }
 
     private SearchTokens parseTokens(String query) {
@@ -438,10 +444,13 @@ public class EventService {
     public Page<EventDTO> getEventsByOrganiser(Long organiserId, Pageable pageable, boolean past) {
         Page<Event> page = eventRepository.findByOrganiserId(organiserId, pageable);
         Instant now = Instant.now();
-        List<EventDTO> filtered = page.getContent().stream()
+        List<Event> filteredEvents = page.getContent().stream()
                 .filter(e -> past ? EventTimingUtils.effectiveEnd(e).isBefore(now) : !EventTimingUtils.effectiveEnd(e).isBefore(now))
                 .sorted(past ? Comparator.comparing(Event::getEventDate).reversed() : Comparator.comparing(Event::getEventDate))
-                .map(this::convertToDTO)
+                .collect(Collectors.toList());
+        Map<Long, GroupRatingSummary> ratingsMap = buildRatingsMap(filteredEvents);
+        List<EventDTO> filtered = filteredEvents.stream()
+                .map(event -> convertToDTO(event, ratingsMap.get(event.getGroup().getId())))
                 .collect(Collectors.toList());
         return new PageImpl<>(filtered, pageable, filtered.size());
     }
@@ -484,8 +493,9 @@ public class EventService {
         events.sort(comparator);
         
         // Convert to DTOs
+        Map<Long, GroupRatingSummary> ratingsMap = buildRatingsMap(events);
         List<EventDTO> eventDTOs = events.stream()
-                .map(this::convertToDTO)
+                .map(event -> convertToDTO(event, ratingsMap.get(event.getGroup().getId())))
                 .collect(Collectors.toList());
         
         // Create pageable response
@@ -502,8 +512,9 @@ public class EventService {
     @Transactional(readOnly = true)
     @Cacheable(value = "events", key = "'group_' + #groupId + '_' + #pageable.pageNumber + '_' + #pageable.pageSize")
     public Page<EventDTO> getEventsByGroup(Long groupId, Pageable pageable) {
-        return eventRepository.findByGroupId(groupId, pageable)
-                .map(this::convertToDTO);
+        Page<Event> page = eventRepository.findByGroupId(groupId, pageable);
+        Map<Long, GroupRatingSummary> ratingsMap = buildRatingsMap(page.getContent());
+        return page.map(event -> convertToDTO(event, ratingsMap.get(event.getGroup().getId())));
     }
     
     // ============================================================
@@ -801,32 +812,53 @@ public class EventService {
                 .collect(Collectors.toList());
     }
 
+    private Map<Long, GroupRatingSummary> buildRatingsMap(List<Event> events) {
+        Set<Long> groupIds = events.stream()
+                .map(e -> e.getGroup().getId())
+                .collect(Collectors.toSet());
+        Map<Long, GroupRatingSummary> map = new HashMap<>();
+        groupRatingSummaryRepository.findByGroupIdIn(groupIds)
+                .forEach(r -> map.put(r.getGroupId(), r));
+        return map;
+    }
+
     private EventDTO convertToDTO(Event event) {
         if (event == null) {
             return null;
         }
-        
+        Group group = event.getGroup();
+        GroupRatingSummary groupRating = group != null
+                ? groupRatingSummaryRepository.findByGroupId(group.getId()).orElse(null)
+                : null;
+        return convertToDTO(event, groupRating);
+    }
+
+    private EventDTO convertToDTO(Event event, GroupRatingSummary groupRating) {
+        if (event == null) {
+            return null;
+        }
+
         // Get the group
         Group group = event.getGroup();
         if (group == null) {
             throw new IllegalStateException("Event must belong to a group");
         }
-        
+
         // Get the primary organiser from the group
         Member primaryOrganiser = group.getPrimaryOrganiser();
         if (primaryOrganiser == null) {
             throw new IllegalStateException("Group must have a primary organiser");
         }
-        
+
         // Get the activity from the group
         Activity activity = group.getActivity();
         if (activity == null) {
             throw new IllegalStateException("Group must be associated with an activity");
         }
-        
+
         // Get participants count (including guests)
         int participantCount = getTotalHeadcount(event);
-        
+
         // Get participant IDs for the DTO
         Set<Long> participantIds = event.getParticipants() != null ?
                 event.getParticipants().stream()
@@ -835,7 +867,7 @@ public class EventService {
                         .map(p -> p.getMember().getId())
                         .collect(Collectors.toSet()) :
                 new HashSet<>();
-        
+
         // Get host member info if present
         Long hostMemberId = null;
         String hostMemberName = null;
@@ -848,8 +880,6 @@ public class EventService {
                         ? event.getHostMember().getDisplayName()
                         : event.getHostMember().getEmail());
         }
-
-        GroupRatingSummary groupRating = groupRatingSummaryRepository.findByGroupId(group.getId()).orElse(null);
 
         return EventDTO.builder()
                 .id(event.getId())
@@ -892,9 +922,9 @@ public class EventService {
                 .requirements(event.getRequirements() != null ? new HashSet<>(event.getRequirements()) : new HashSet<>())
                 .includedItems(event.getIncludedItems() != null ? new HashSet<>(event.getIncludedItems()) : new HashSet<>())
                 .cancellationPolicy(event.getCancellationPolicy())
-                .averageRating(event.getAverageRating() != null ? new BigDecimal(event.getAverageRating()) : BigDecimal.ZERO)
+                .averageRating(event.getAverageRating() != null ? BigDecimal.valueOf(event.getAverageRating()) : BigDecimal.ZERO)
                 .totalReviews(event.getTotalReviews() != null ? event.getTotalReviews() : 0)
-                .groupAverageRating(groupRating != null && groupRating.getAverageRating() != null ? new BigDecimal(groupRating.getAverageRating()) : null)
+                .groupAverageRating(groupRating != null && groupRating.getAverageRating() != null ? BigDecimal.valueOf(groupRating.getAverageRating()) : null)
                 .groupTotalReviews(groupRating != null ? groupRating.getTotalReviews() : 0)
                 .createdAt(event.getCreatedAt())
                 .updatedAt(event.getUpdatedAt())
@@ -1002,9 +1032,9 @@ public class EventService {
                 .requirements(event.getRequirements() != null ? new HashSet<>(event.getRequirements()) : new HashSet<>())
                 .includedItems(event.getIncludedItems() != null ? new HashSet<>(event.getIncludedItems()) : new HashSet<>())
                 .cancellationPolicy(event.getCancellationPolicy())
-                .averageRating(event.getAverageRating() != null ? new BigDecimal(event.getAverageRating()) : BigDecimal.ZERO)
+                .averageRating(event.getAverageRating() != null ? BigDecimal.valueOf(event.getAverageRating()) : BigDecimal.ZERO)
                 .totalReviews(event.getTotalReviews() != null ? event.getTotalReviews() : 0)
-                .groupAverageRating(groupRating != null && groupRating.getAverageRating() != null ? new BigDecimal(groupRating.getAverageRating()) : null)
+                .groupAverageRating(groupRating != null && groupRating.getAverageRating() != null ? BigDecimal.valueOf(groupRating.getAverageRating()) : null)
                 .groupTotalReviews(groupRating != null ? groupRating.getTotalReviews() : 0)
                 .createdAt(event.getCreatedAt())
                 .updatedAt(event.getUpdatedAt())
@@ -1084,7 +1114,7 @@ public class EventService {
                 .cancellationPolicy(null)
                 .averageRating(BigDecimal.ZERO)
                 .totalReviews(0)
-                .groupAverageRating(groupRating != null && groupRating.getAverageRating() != null ? new BigDecimal(groupRating.getAverageRating()) : null)
+                .groupAverageRating(groupRating != null && groupRating.getAverageRating() != null ? BigDecimal.valueOf(groupRating.getAverageRating()) : null)
                 .groupTotalReviews(groupRating != null ? groupRating.getTotalReviews() : 0)
                 .updatedAt(null)
                 .userIsGroupMember(false)

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -107,13 +107,16 @@ export default function EventCard({ event, isPast = false }) {
               </div>
             )}
 
-            {event.totalReviews >= 3 && (
-              <div className="flex items-center gap-1.5 pt-1">
-                <Star className="w-3.5 h-3.5 fill-yellow-400 text-yellow-400" />
-                <span className="font-semibold text-xs">{Number(event.averageRating).toFixed(1)}</span>
-                <span className="text-xs text-gray-500">
-                  ({event.totalReviews})
-                </span>
+            {event.groupName && (
+              <div className="flex items-center gap-1 pt-1 text-xs text-gray-500">
+                <span className="truncate">{event.groupName}</span>
+                {event.groupTotalReviews >= 3 && event.groupAverageRating && (
+                  <>
+                    <span className="text-gray-300">·</span>
+                    <Star className="w-3 h-3 fill-yellow-400 text-yellow-400 shrink-0" />
+                    <span className="font-semibold text-gray-700">{Number(event.groupAverageRating).toFixed(1)}</span>
+                  </>
+                )}
               </div>
             )}
           </div>
@@ -135,15 +138,17 @@ export default function EventCard({ event, isPast = false }) {
                 <span className="truncate">{event.location}</span>
               </div>
             )}
-            {event.totalReviews >= 3 && (
-              <div className="flex items-center gap-2 mt-2">
-                <div className="flex items-center gap-1">
-                  <Star className="w-4 h-4 fill-yellow-400 text-yellow-400" />
-                  <span className="font-semibold text-sm">{Number(event.averageRating).toFixed(1)}</span>
-                </div>
-                <span className="text-xs text-gray-600">
-                  ({event.totalReviews} {event.totalReviews === 1 ? 'review' : 'reviews'})
-                </span>
+            {event.groupName && (
+              <div className="flex items-center gap-1.5 text-sm text-gray-500">
+                <span className="truncate">{event.groupName}</span>
+                {event.groupTotalReviews >= 3 && event.groupAverageRating && (
+                  <>
+                    <span className="text-gray-300">·</span>
+                    <Star className="w-3.5 h-3.5 fill-yellow-400 text-yellow-400 shrink-0" />
+                    <span className="font-semibold text-gray-700">{Number(event.groupAverageRating).toFixed(1)}</span>
+                    <span className="text-xs text-gray-400">({event.groupTotalReviews})</span>
+                  </>
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -108,9 +108,9 @@ export default function EventCard({ event, isPast = false }) {
             )}
 
             {event.groupName && (
-              <div className="flex items-center gap-1 pt-1 text-xs text-gray-500">
-                <span>by</span>
-                <span className="truncate">{event.groupName}</span>
+              <div className="flex items-center gap-1">
+                <span className="text-gray-400">by</span>
+                <span className="truncate text-gray-600">{event.groupName}</span>
                 {event.groupTotalReviews >= 3 && event.groupAverageRating && (
                   <>
                     <span className="text-gray-300">·</span>
@@ -140,15 +140,14 @@ export default function EventCard({ event, isPast = false }) {
               </div>
             )}
             {event.groupName && (
-              <div className="flex items-center gap-1.5 text-sm text-gray-500">
-                <span>by</span>
+              <div className="flex items-center gap-2 text-sm text-gray-600">
+                <span className="text-gray-400">by</span>
                 <span className="truncate">{event.groupName}</span>
                 {event.groupTotalReviews >= 3 && event.groupAverageRating && (
                   <>
                     <span className="text-gray-300">·</span>
                     <Star className="w-3.5 h-3.5 fill-yellow-400 text-yellow-400 shrink-0" />
-                    <span className="font-semibold text-gray-700">{Number(event.groupAverageRating).toFixed(1)}</span>
-                    <span className="text-xs text-gray-400">({event.groupTotalReviews})</span>
+                    <span className="font-semibold">{Number(event.groupAverageRating).toFixed(1)}</span>
                   </>
                 )}
               </div>

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -111,11 +111,12 @@ export default function EventCard({ event, isPast = false }) {
               <div className="flex items-center gap-1">
                 <span className="text-gray-400">by</span>
                 <span className="truncate text-gray-600">{event.groupName}</span>
-                {event.groupTotalReviews >= 3 && event.groupAverageRating && (
+                {event.groupTotalReviews >= 3 && event.groupAverageRating != null && (
                   <>
                     <span className="text-gray-300">·</span>
                     <Star className="w-3 h-3 fill-yellow-400 text-yellow-400 shrink-0" />
                     <span className="font-semibold text-gray-700">{Number(event.groupAverageRating).toFixed(1)}</span>
+                    <span className="text-gray-400">({event.groupTotalReviews})</span>
                   </>
                 )}
               </div>
@@ -143,11 +144,12 @@ export default function EventCard({ event, isPast = false }) {
               <div className="flex items-center gap-2 text-sm text-gray-600">
                 <span className="text-gray-400">by</span>
                 <span className="truncate">{event.groupName}</span>
-                {event.groupTotalReviews >= 3 && event.groupAverageRating && (
+                {event.groupTotalReviews >= 3 && event.groupAverageRating != null && (
                   <>
                     <span className="text-gray-300">·</span>
                     <Star className="w-3.5 h-3.5 fill-yellow-400 text-yellow-400 shrink-0" />
                     <span className="font-semibold">{Number(event.groupAverageRating).toFixed(1)}</span>
+                    <span className="text-gray-500">({event.groupTotalReviews})</span>
                   </>
                 )}
               </div>

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -109,6 +109,7 @@ export default function EventCard({ event, isPast = false }) {
 
             {event.groupName && (
               <div className="flex items-center gap-1 pt-1 text-xs text-gray-500">
+                <span>by</span>
                 <span className="truncate">{event.groupName}</span>
                 {event.groupTotalReviews >= 3 && event.groupAverageRating && (
                   <>
@@ -140,6 +141,7 @@ export default function EventCard({ event, isPast = false }) {
             )}
             {event.groupName && (
               <div className="flex items-center gap-1.5 text-sm text-gray-500">
+                <span>by</span>
                 <span className="truncate">{event.groupName}</span>
                 {event.groupTotalReviews >= 3 && event.groupAverageRating && (
                   <>

--- a/frontend/src/pages/EventDetailPage.jsx
+++ b/frontend/src/pages/EventDetailPage.jsx
@@ -15,6 +15,7 @@ import AddToCalendar from '../components/AddToCalendar'
 import ContactInfoPopover from '../components/ContactInfoPopover'
 import AddToCalendarModal from '../components/AddToCalendarModal'
 import GroupGuidelinesModal from '../components/GroupGuidelinesModal'
+import RatingStars from '../components/RatingStars'
 import ShareButton from '../components/ShareButton'
 import EventFlyerModal from '../components/EventFlyerModal'
 import InviteMembersModal from '../components/InviteMembersModal'
@@ -1181,9 +1182,9 @@ export default function EventDetailPage() {
                     <p className="text-[11px] font-medium text-purple-500 uppercase tracking-wide leading-none mb-0.5">Organised by</p>
                     <h2 className="text-sm lg:text-base font-bold text-gray-900 truncate">{displayEvent.groupName}</h2>
                     {displayEvent.groupTotalReviews >= 3 && displayEvent.groupAverageRating && (
-                      <div className="flex items-center gap-1 mt-0.5">
-                        <Star className="w-3 h-3 fill-yellow-400 text-yellow-400 shrink-0" />
-                        <span className="text-xs font-semibold text-gray-700">{Number(displayEvent.groupAverageRating).toFixed(1)}</span>
+                      <div className="flex items-center gap-1.5 mt-0.5">
+                        <RatingStars rating={Number(displayEvent.groupAverageRating)} size="sm" />
+                        <span className="text-xs text-gray-500">{displayEvent.groupTotalReviews} {displayEvent.groupTotalReviews === 1 ? 'review' : 'reviews'}</span>
                       </div>
                     )}
                   </div>

--- a/frontend/src/pages/EventDetailPage.jsx
+++ b/frontend/src/pages/EventDetailPage.jsx
@@ -1180,6 +1180,12 @@ export default function EventDetailPage() {
                   <div className="flex-1 min-w-0">
                     <p className="text-[11px] font-medium text-purple-500 uppercase tracking-wide leading-none mb-0.5">Organised by</p>
                     <h2 className="text-sm lg:text-base font-bold text-gray-900 truncate">{displayEvent.groupName}</h2>
+                    {displayEvent.groupTotalReviews >= 3 && displayEvent.groupAverageRating && (
+                      <div className="flex items-center gap-1 mt-0.5">
+                        <Star className="w-3 h-3 fill-yellow-400 text-yellow-400 shrink-0" />
+                        <span className="text-xs font-semibold text-gray-700">{Number(displayEvent.groupAverageRating).toFixed(1)}</span>
+                      </div>
+                    )}
                   </div>
 
                   {/* Badge + arrow */}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -548,6 +548,7 @@ export default function HomePage() {
                         </div>
                         {event.groupName && (
                           <div className="flex items-center gap-1.5 text-sm text-gray-500">
+                            <span>by</span>
                             <span className="truncate">{event.groupName}</span>
                             {event.groupTotalReviews >= 3 && event.groupAverageRating && (
                               <>
@@ -702,6 +703,7 @@ export default function HomePage() {
                           </div>
                           {event.groupName && (
                             <div className="flex items-center gap-1.5 text-sm text-gray-500">
+                              <span>by</span>
                               <span className="truncate">{event.groupName}</span>
                               {event.groupTotalReviews >= 3 && event.groupAverageRating && (
                                 <>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -547,15 +547,14 @@ export default function HomePage() {
                           <span className="truncate">{event.location}</span>
                         </div>
                         {event.groupName && (
-                          <div className="flex items-center gap-1.5 text-sm text-gray-500">
-                            <span>by</span>
+                          <div className="flex items-center gap-2 text-sm text-gray-600">
+                            <span className="text-gray-400">by</span>
                             <span className="truncate">{event.groupName}</span>
                             {event.groupTotalReviews >= 3 && event.groupAverageRating && (
                               <>
                                 <span className="text-gray-300">·</span>
                                 <Star className="w-3.5 h-3.5 fill-yellow-400 text-yellow-400 shrink-0" />
-                                <span className="font-semibold text-gray-700">{Number(event.groupAverageRating).toFixed(1)}</span>
-                                <span className="text-xs text-gray-400">({event.groupTotalReviews})</span>
+                                <span className="font-semibold">{Number(event.groupAverageRating).toFixed(1)}</span>
                               </>
                             )}
                           </div>
@@ -702,15 +701,14 @@ export default function HomePage() {
                             <span className="truncate">{event.location}</span>
                           </div>
                           {event.groupName && (
-                            <div className="flex items-center gap-1.5 text-sm text-gray-500">
-                              <span>by</span>
+                            <div className="flex items-center gap-2 text-sm text-gray-600">
+                              <span className="text-gray-400">by</span>
                               <span className="truncate">{event.groupName}</span>
                               {event.groupTotalReviews >= 3 && event.groupAverageRating && (
                                 <>
                                   <span className="text-gray-300">·</span>
                                   <Star className="w-3.5 h-3.5 fill-yellow-400 text-yellow-400 shrink-0" />
-                                  <span className="font-semibold text-gray-700">{Number(event.groupAverageRating).toFixed(1)}</span>
-                                  <span className="text-xs text-gray-400">({event.groupTotalReviews})</span>
+                                  <span className="font-semibold">{Number(event.groupAverageRating).toFixed(1)}</span>
                                 </>
                               )}
                             </div>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -546,6 +546,19 @@ export default function HomePage() {
                           </svg>
                           <span className="truncate">{event.location}</span>
                         </div>
+                        {event.groupName && (
+                          <div className="flex items-center gap-1.5 text-sm text-gray-500">
+                            <span className="truncate">{event.groupName}</span>
+                            {event.groupTotalReviews >= 3 && event.groupAverageRating && (
+                              <>
+                                <span className="text-gray-300">·</span>
+                                <Star className="w-3.5 h-3.5 fill-yellow-400 text-yellow-400 shrink-0" />
+                                <span className="font-semibold text-gray-700">{Number(event.groupAverageRating).toFixed(1)}</span>
+                                <span className="text-xs text-gray-400">({event.groupTotalReviews})</span>
+                              </>
+                            )}
+                          </div>
+                        )}
                       </div>
                       <div className="flex items-center justify-between pt-3 border-t border-gray-100">
                         <div className="flex items-center gap-2">
@@ -687,6 +700,19 @@ export default function HomePage() {
                             </svg>
                             <span className="truncate">{event.location}</span>
                           </div>
+                          {event.groupName && (
+                            <div className="flex items-center gap-1.5 text-sm text-gray-500">
+                              <span className="truncate">{event.groupName}</span>
+                              {event.groupTotalReviews >= 3 && event.groupAverageRating && (
+                                <>
+                                  <span className="text-gray-300">·</span>
+                                  <Star className="w-3.5 h-3.5 fill-yellow-400 text-yellow-400 shrink-0" />
+                                  <span className="font-semibold text-gray-700">{Number(event.groupAverageRating).toFixed(1)}</span>
+                                  <span className="text-xs text-gray-400">({event.groupTotalReviews})</span>
+                                </>
+                              )}
+                            </div>
+                          )}
                         </div>
                         <div className="flex items-center justify-between pt-3 border-t border-gray-100">
                           {/* Desktop: badge + text on left */}


### PR DESCRIPTION
## Summary
- Replaces per-event rating on the home screen card with the group's aggregated rating alongside the group name
- Gives attendees a trust signal for upcoming events that have no reviews yet
- Group name always shows; rating appended (`· ★ 4.7 (38)`) only when the group has ≥ 3 reviews

## Changes
- **EventDTO**: added `groupAverageRating` and `groupTotalReviews` fields
- **EventService**: populates those fields from `GroupRatingSummary` in all three `convertToDTO` paths (full, full+member, partial for non-members)
- **EventCard**: both mobile and desktop rows replaced with `Group Name · ★ X.X (N)` — no extra card height since it reuses the existing rating row slot

## Test plan
- [ ] Home screen shows group name on every event card
- [ ] Groups with ≥ 3 reviews show the star rating alongside the name
- [ ] Groups with < 3 reviews show name only (no star)
- [ ] Backend compiles clean (`./gradlew compileJava`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)