### PR TITLE
feat: show attendee no-show reliability rate to host

### DIFF
--- a/backend/src/main/java/com/organiser/platform/dto/MemberDTO.java
+++ b/backend/src/main/java/com/organiser/platform/dto/MemberDTO.java
@@ -46,4 +46,6 @@ public class MemberDTO {
     private String participationStatus; // e.g. REGISTERED, CONFIRMED, ATTENDED, NO_SHOW, CANCELLED, WAITLISTED
     private LocalDateTime cancelledAt;
     private LocalDateTime waitlistJoinedAt;
+    private Integer totalEventsJoined;  // across all platform events (excludes CANCELLED/WAITLISTED)
+    private Integer totalNoShows;       // lifetime no-show count
 }

--- a/backend/src/main/java/com/organiser/platform/repository/EventParticipantRepository.java
+++ b/backend/src/main/java/com/organiser/platform/repository/EventParticipantRepository.java
@@ -28,10 +28,14 @@ public interface EventParticipantRepository extends JpaRepository<EventParticipa
     
     long countByEventIdAndStatus(Long eventId, EventParticipant.ParticipationStatus status);
     
-    long countByMemberIdAndStatus(Long memberId, EventParticipant.ParticipationStatus status);
+    @Query("SELECT ep.member.id, COUNT(ep) FROM EventParticipant ep WHERE ep.member.id IN :memberIds AND ep.status IN :statuses GROUP BY ep.member.id")
+    java.util.List<Object[]> countJoinedByMemberIds(
+            @Param("memberIds") java.util.Collection<Long> memberIds,
+            @Param("statuses") java.util.Collection<EventParticipant.ParticipationStatus> statuses);
 
-    long countByMemberIdAndStatusIn(Long memberId,
-            java.util.Collection<EventParticipant.ParticipationStatus> statuses);
+    @Query("SELECT ep.member.id, COUNT(ep) FROM EventParticipant ep WHERE ep.member.id IN :memberIds AND ep.status = 'NO_SHOW' GROUP BY ep.member.id")
+    java.util.List<Object[]> countNoShowsByMemberIds(
+            @Param("memberIds") java.util.Collection<Long> memberIds);
 
     // Admin dashboard queries
     Long countByMemberId(Long memberId);

--- a/backend/src/main/java/com/organiser/platform/repository/EventParticipantRepository.java
+++ b/backend/src/main/java/com/organiser/platform/repository/EventParticipantRepository.java
@@ -28,6 +28,11 @@ public interface EventParticipantRepository extends JpaRepository<EventParticipa
     
     long countByEventIdAndStatus(Long eventId, EventParticipant.ParticipationStatus status);
     
+    long countByMemberIdAndStatus(Long memberId, EventParticipant.ParticipationStatus status);
+
+    long countByMemberIdAndStatusIn(Long memberId,
+            java.util.Collection<EventParticipant.ParticipationStatus> statuses);
+
     // Admin dashboard queries
     Long countByMemberId(Long memberId);
 

--- a/backend/src/main/java/com/organiser/platform/service/EventService.java
+++ b/backend/src/main/java/com/organiser/platform/service/EventService.java
@@ -1103,13 +1103,35 @@ public class EventService {
         // Get the primary organiser of the group (who is the event organiser)
         Long eventOrganiserId = event.getGroup().getPrimaryOrganiser().getId();
         Long groupId = event.getGroup().getId();
-        
+
+        // Reliability stats are host-only — bulk-fetch before streaming to avoid N+1
+        boolean requesterIsHost = requesterId != null
+                && event.getHostMember() != null
+                && event.getHostMember().getId().equals(requesterId);
+
+        java.util.Map<Long, Integer> joinedByMemberId = new java.util.HashMap<>();
+        java.util.Map<Long, Integer> noShowsByMemberId = new java.util.HashMap<>();
+        if (requesterIsHost) {
+            java.util.List<Long> memberIds = event.getParticipants().stream()
+                    .map(p -> p.getMember().getId())
+                    .collect(Collectors.toList());
+            java.util.List<EventParticipant.ParticipationStatus> joinedStatuses = java.util.List.of(
+                    EventParticipant.ParticipationStatus.REGISTERED,
+                    EventParticipant.ParticipationStatus.CONFIRMED,
+                    EventParticipant.ParticipationStatus.ATTENDED,
+                    EventParticipant.ParticipationStatus.NO_SHOW);
+            eventParticipantRepository.countJoinedByMemberIds(memberIds, joinedStatuses)
+                    .forEach(row -> joinedByMemberId.put((Long) row[0], Math.toIntExact((Long) row[1])));
+            eventParticipantRepository.countNoShowsByMemberIds(memberIds)
+                    .forEach(row -> noShowsByMemberId.put((Long) row[0], Math.toIntExact((Long) row[1])));
+        }
+
         return event.getParticipants().stream()
                 .map(participant -> {
                     Member member = participant.getMember();
                     boolean isDeleted = Boolean.FALSE.equals(member.getActive());
                     boolean isBanned = bannedMemberRepository.existsByGroupIdAndMemberId(groupId, member.getId());
-                    
+
                     // Determine display name: "Deleted user" for deleted, "Former Member" for banned, or actual name
                     String displayName;
                     if (isDeleted) {
@@ -1119,21 +1141,12 @@ public class EventService {
                     } else {
                         displayName = member.getDisplayName();
                     }
-                    
+
                     Integer totalEventsJoined = null;
                     Integer totalNoShows = null;
-                    if (!isDeleted && !isBanned) {
-                        long joined = eventParticipantRepository.countByMemberIdAndStatusIn(
-                                member.getId(),
-                                java.util.List.of(
-                                        EventParticipant.ParticipationStatus.REGISTERED,
-                                        EventParticipant.ParticipationStatus.CONFIRMED,
-                                        EventParticipant.ParticipationStatus.ATTENDED,
-                                        EventParticipant.ParticipationStatus.NO_SHOW));
-                        long noShows = eventParticipantRepository.countByMemberIdAndStatus(
-                                member.getId(), EventParticipant.ParticipationStatus.NO_SHOW);
-                        totalEventsJoined = (int) joined;
-                        totalNoShows = (int) noShows;
+                    if (requesterIsHost && !isDeleted && !isBanned) {
+                        totalEventsJoined = joinedByMemberId.getOrDefault(member.getId(), 0);
+                        totalNoShows = noShowsByMemberId.getOrDefault(member.getId(), 0);
                     }
 
                     return com.organiser.platform.dto.MemberDTO.builder()

--- a/backend/src/main/java/com/organiser/platform/service/EventService.java
+++ b/backend/src/main/java/com/organiser/platform/service/EventService.java
@@ -1120,6 +1120,22 @@ public class EventService {
                         displayName = member.getDisplayName();
                     }
                     
+                    Integer totalEventsJoined = null;
+                    Integer totalNoShows = null;
+                    if (!isDeleted && !isBanned) {
+                        long joined = eventParticipantRepository.countByMemberIdAndStatusIn(
+                                member.getId(),
+                                java.util.List.of(
+                                        EventParticipant.ParticipationStatus.REGISTERED,
+                                        EventParticipant.ParticipationStatus.CONFIRMED,
+                                        EventParticipant.ParticipationStatus.ATTENDED,
+                                        EventParticipant.ParticipationStatus.NO_SHOW));
+                        long noShows = eventParticipantRepository.countByMemberIdAndStatus(
+                                member.getId(), EventParticipant.ParticipationStatus.NO_SHOW);
+                        totalEventsJoined = (int) joined;
+                        totalNoShows = (int) noShows;
+                    }
+
                     return com.organiser.platform.dto.MemberDTO.builder()
                             .id((isDeleted || isBanned) ? null : member.getId())
                             // PRIVACY: Never expose email in participant lists (Meetup.com approach)
@@ -1135,6 +1151,8 @@ public class EventService {
                             .participationStatus(participant.getStatus() != null ? participant.getStatus().name() : null)
                             .cancelledAt(participant.getCancelledAt())
                             .waitlistJoinedAt(participant.getWaitlistJoinedAt())
+                            .totalEventsJoined(totalEventsJoined)
+                            .totalNoShows(totalNoShows)
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/frontend/src/pages/EventAttendeesPage.jsx
+++ b/frontend/src/pages/EventAttendeesPage.jsx
@@ -116,7 +116,7 @@ export default function EventAttendeesPage() {
             <>
               {activeTab === 'attendees' && (
                 attending.length > 0
-                  ? attending.map(p => <MemberRow key={p.id} participant={p} onClick={() => navigate(`/members/${p.id}`)} showChat currentUserId={user?.id} />)
+                  ? attending.map(p => <MemberRow key={p.id} participant={p} onClick={() => navigate(`/members/${p.id}`)} showChat currentUserId={user?.id} showReliability={isHost} />)
                   : <Empty message="No attendees yet" />
               )}
 
@@ -141,6 +141,7 @@ export default function EventAttendeesPage() {
                         currentUserId={user?.id}
                         onUndo={isHost ? () => unmarkNoShowMutation.mutate(p.id) : undefined}
                         undoLoading={unmarkNoShowMutation.isPending && unmarkNoShowMutation.variables === p.id}
+                        showReliability={isHost}
                       />
                     ))
                   : <Empty message="No no-shows" />
@@ -160,19 +161,40 @@ export default function EventAttendeesPage() {
 }
 
 
-function MemberRow({ participant, badge, badgeColor, onClick, showChat, currentUserId, onUndo, undoLoading }) {
+function ReliabilityBadge({ totalEventsJoined, totalNoShows }) {
+  if (totalEventsJoined == null || totalEventsJoined < 2) return null
+  const rate = Math.round((totalNoShows / totalEventsJoined) * 100)
+  let className
+  if (rate === 0) {
+    className = 'bg-green-100 text-green-700'
+  } else if (rate <= 30) {
+    className = 'bg-amber-100 text-amber-700'
+  } else {
+    className = 'bg-red-100 text-red-700'
+  }
+  return (
+    <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${className}`}>
+      {rate}% no-show
+    </span>
+  )
+}
+
+function MemberRow({ participant, badge, badgeColor, onClick, showChat, currentUserId, onUndo, undoLoading, showReliability }) {
   return (
     <div className="flex items-center gap-3 p-3 bg-gradient-to-r from-purple-50 to-pink-50 rounded-xl">
       <div className="flex-shrink-0 cursor-pointer" onClick={onClick}>
         <ProfileAvatar member={participant} size="md" />
       </div>
       <div className="flex-1 min-w-0 cursor-pointer" onClick={onClick}>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <p className="font-semibold text-gray-900 text-sm truncate hover:text-purple-600 transition-colors">{participant.displayName || 'Anonymous'}</p>
           {badge && (
             <span className={`text-xs px-1.5 py-0.5 rounded font-medium bg-${badgeColor}-100 text-${badgeColor}-600`}>
               {badge}
             </span>
+          )}
+          {showReliability && (
+            <ReliabilityBadge totalEventsJoined={participant.totalEventsJoined} totalNoShows={participant.totalNoShows} />
           )}
         </div>
         {participant.guestCount > 0 && (


### PR DESCRIPTION
## Summary
- Adds `totalEventsJoined` and `totalNoShows` fields to `MemberDTO`, populated in `getEventParticipants()`
- Two new count queries in `EventParticipantRepository` aggregate across all platform events
- Frontend shows a `X% no-show` badge next to each attendee name — host-only, hidden from organisers
- Badge colour: green (0%), amber (1–30%), red (>30%); not shown until member has 2+ events

## Test plan
- [ ] As host, open attendees list — each attendee shows their reliability badge
- [ ] Attendee with 0 no-shows shows green "0% no-show"
- [ ] Attendee with no-shows shows amber/red rate
- [ ] Badge is absent for attendees with only 1 event
- [ ] As organiser (not host), open attendees list — no reliability badges visible
- [ ] Deleted/banned members show no badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)