### PR TITLE
feat: allow host to pin up to 3 comments on event

### DIFF
--- a/backend/src/main/java/com/organiser/platform/config/SecurityConfig.java
+++ b/backend/src/main/java/com/organiser/platform/config/SecurityConfig.java
@@ -128,6 +128,7 @@ public class SecurityConfig {
                                 new AntPathRequestMatcher("/api/v1/events/comments/*", "PUT"),
                                 new AntPathRequestMatcher("/api/v1/events/comments/*", "DELETE"),
                                 new AntPathRequestMatcher("/api/v1/events/comments/*/replies", "POST"),
+                                new AntPathRequestMatcher("/api/v1/events/comments/*/pin", "POST"),
                                 new AntPathRequestMatcher("/api/v1/events/replies/*", "PUT"),
                                 new AntPathRequestMatcher("/api/v1/events/replies/*", "DELETE"),
                                 new AntPathRequestMatcher("/api/v1/events/organiser/my-events", "GET"),

--- a/backend/src/main/java/com/organiser/platform/controller/EventCommentController.java
+++ b/backend/src/main/java/com/organiser/platform/controller/EventCommentController.java
@@ -98,6 +98,18 @@ public class EventCommentController {
     }
     
     /**
+     * Toggle pin on a comment (host only)
+     */
+    @PostMapping("/comments/{commentId}/pin")
+    public ResponseEntity<CommentDTO> togglePinComment(
+            @PathVariable Long commentId,
+            Authentication authentication
+    ) {
+        Long userId = getUserIdFromAuth(authentication);
+        return ResponseEntity.ok(commentService.togglePinComment(commentId, userId));
+    }
+
+    /**
      * Delete a reply (authenticated)
      */
     @DeleteMapping("/replies/{replyId}")

--- a/backend/src/main/java/com/organiser/platform/dto/CommentDTO.java
+++ b/backend/src/main/java/com/organiser/platform/dto/CommentDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -23,6 +24,8 @@ public class CommentDTO {
     private Boolean deleted;
     private String content;
     private Boolean edited;
+    private Boolean pinned;
+    private Instant pinnedAt;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Integer replyCount;

--- a/backend/src/main/java/com/organiser/platform/model/EventComment.java
+++ b/backend/src/main/java/com/organiser/platform/model/EventComment.java
@@ -11,6 +11,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,6 +53,13 @@ public class EventComment {
     @Builder.Default
     @Column(nullable = false)
     private Boolean edited = false;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean pinned = false;
+
+    @Column(name = "pinned_at")
+    private Instant pinnedAt;
     
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/src/main/java/com/organiser/platform/repository/EventCommentRepository.java
+++ b/backend/src/main/java/com/organiser/platform/repository/EventCommentRepository.java
@@ -12,10 +12,11 @@ import java.util.List;
 public interface EventCommentRepository extends JpaRepository<EventComment, Long> {
     
     /**
-     * Find all comments for a specific event, ordered by creation date descending
+     * Find all comments for a specific event, ordered pinned-first (by pinnedAt desc),
+     * then by creation date descending.
      */
     @Query("SELECT c FROM EventComment c WHERE c.event.id = :eventId ORDER BY c.pinned DESC, c.pinnedAt DESC, c.createdAt DESC")
-    List<EventComment> findByEventIdOrderByCreatedAtDesc(@Param("eventId") Long eventId);
+    List<EventComment> findByEventIdOrderedForDisplay(@Param("eventId") Long eventId);
 
     @Query("SELECT COUNT(c) FROM EventComment c WHERE c.event.id = :eventId AND c.pinned = true")
     long countPinnedByEventId(@Param("eventId") Long eventId);

--- a/backend/src/main/java/com/organiser/platform/repository/EventCommentRepository.java
+++ b/backend/src/main/java/com/organiser/platform/repository/EventCommentRepository.java
@@ -14,8 +14,11 @@ public interface EventCommentRepository extends JpaRepository<EventComment, Long
     /**
      * Find all comments for a specific event, ordered by creation date descending
      */
-    @Query("SELECT c FROM EventComment c WHERE c.event.id = :eventId ORDER BY c.createdAt DESC")
+    @Query("SELECT c FROM EventComment c WHERE c.event.id = :eventId ORDER BY c.pinned DESC, c.pinnedAt DESC, c.createdAt DESC")
     List<EventComment> findByEventIdOrderByCreatedAtDesc(@Param("eventId") Long eventId);
+
+    @Query("SELECT COUNT(c) FROM EventComment c WHERE c.event.id = :eventId AND c.pinned = true")
+    long countPinnedByEventId(@Param("eventId") Long eventId);
     
     /**
      * Count comments for a specific event

--- a/backend/src/main/java/com/organiser/platform/repository/EventRepository.java
+++ b/backend/src/main/java/com/organiser/platform/repository/EventRepository.java
@@ -4,9 +4,12 @@ import com.organiser.platform.model.Event;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
 
 import java.time.Instant;
 import java.util.List;
@@ -14,6 +17,10 @@ import java.util.Optional;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Event e WHERE e.id = :id")
+    Optional<Event> findByIdWithLock(@Param("id") Long id);
     
     Page<Event> findByStatus(Event.EventStatus status, Pageable pageable);
     

--- a/backend/src/main/java/com/organiser/platform/service/EventCommentService.java
+++ b/backend/src/main/java/com/organiser/platform/service/EventCommentService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -146,6 +147,35 @@ public class EventCommentService {
         commentRepository.delete(comment);
     }
     
+    /**
+     * Toggle pin on a comment.
+     * Only the event host can pin/unpin. Max 3 pinned comments per event.
+     */
+    @Transactional
+    public CommentDTO togglePinComment(Long commentId, Long memberId) {
+        EventComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new RuntimeException("Comment not found"));
+
+        Event event = comment.getEvent();
+        if (event.getHostMember() == null || !event.getHostMember().getId().equals(memberId)) {
+            throw new RuntimeException("Only the event host can pin comments");
+        }
+
+        if (Boolean.TRUE.equals(comment.getPinned())) {
+            comment.setPinned(false);
+            comment.setPinnedAt(null);
+        } else {
+            long currentPinned = commentRepository.countPinnedByEventId(event.getId());
+            if (currentPinned >= 3) {
+                throw new RuntimeException("You can pin at most 3 comments per event");
+            }
+            comment.setPinned(true);
+            comment.setPinnedAt(Instant.now());
+        }
+
+        return convertToDTO(commentRepository.save(comment));
+    }
+
     // ============================================================
     // PUBLIC METHODS - Reply Operations
     // ============================================================
@@ -239,6 +269,8 @@ public class EventCommentService {
                 .deleted(deleted)
                 .content(comment.getContent())
                 .edited(comment.getEdited())
+                .pinned(comment.getPinned())
+                .pinnedAt(comment.getPinnedAt())
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())
                 .replyCount(comment.getReplyCount())

--- a/backend/src/main/java/com/organiser/platform/service/EventCommentService.java
+++ b/backend/src/main/java/com/organiser/platform/service/EventCommentService.java
@@ -68,7 +68,7 @@ public class EventCommentService {
             }
         }
         
-        List<EventComment> comments = commentRepository.findByEventIdOrderByCreatedAtDesc(eventId);
+        List<EventComment> comments = commentRepository.findByEventIdOrderedForDisplay(eventId);
         return comments.stream()
                 .map(this::convertToDTO)
                 .collect(Collectors.toList());
@@ -158,8 +158,11 @@ public class EventCommentService {
 
         Event event = comment.getEvent();
         if (event.getHostMember() == null || !event.getHostMember().getId().equals(memberId)) {
-            throw new RuntimeException("Only the event host can pin comments");
+            throw new IllegalArgumentException("Only the event host can pin comments");
         }
+
+        // Acquire a pessimistic write lock on the event row to serialise concurrent pin requests
+        eventRepository.findByIdWithLock(event.getId());
 
         if (Boolean.TRUE.equals(comment.getPinned())) {
             comment.setPinned(false);
@@ -167,7 +170,7 @@ public class EventCommentService {
         } else {
             long currentPinned = commentRepository.countPinnedByEventId(event.getId());
             if (currentPinned >= 3) {
-                throw new RuntimeException("You can pin at most 3 comments per event");
+                throw new IllegalArgumentException("You can pin at most 3 comments per event");
             }
             comment.setPinned(true);
             comment.setPinnedAt(Instant.now());

--- a/backend/src/main/resources/db/migration/postgresql/V55__add_pin_to_event_comments.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V55__add_pin_to_event_comments.sql
@@ -1,0 +1,3 @@
+ALTER TABLE event_comments
+    ADD COLUMN pinned     BOOLEAN                  NOT NULL DEFAULT FALSE,
+    ADD COLUMN pinned_at  TIMESTAMP WITH TIME ZONE;

--- a/frontend/src/components/CommentSection.jsx
+++ b/frontend/src/components/CommentSection.jsx
@@ -134,7 +134,7 @@ export default function CommentSection({ eventId, isHost }) {
       queryClient.invalidateQueries(['eventComments', eventId])
     },
     onError: (error) => {
-      toast.error(error.response?.data?.message || 'Failed to pin comment')
+      toast.error(error.response?.data?.message || 'Failed to update pin')
     },
   })
 
@@ -364,6 +364,7 @@ export default function CommentSection({ eventId, isHost }) {
                               disabled={pinCommentMutation.isLoading}
                               className={`p-1.5 rounded-lg transition-colors hover:bg-white ${comment.pinned ? 'text-orange-500 hover:text-orange-600' : 'text-gray-400 hover:text-orange-500'}`}
                               title={comment.pinned ? 'Unpin comment' : 'Pin comment'}
+                              aria-label={comment.pinned ? 'Unpin comment' : 'Pin comment'}
                             >
                               <Pin className="h-3.5 w-3.5" />
                             </button>

--- a/frontend/src/components/CommentSection.jsx
+++ b/frontend/src/components/CommentSection.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { MessageCircle, Send, Edit2, Trash2, CornerDownRight, Lock, Loader, X } from 'lucide-react'
+import { MessageCircle, Send, Edit2, Trash2, CornerDownRight, Lock, Loader, X, Pin } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 import toast from 'react-hot-toast'
 import { commentsAPI, membersAPI } from '../lib/api'
@@ -10,7 +10,7 @@ import ProfileAvatar from './ProfileAvatar'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
-export default function CommentSection({ eventId }) {
+export default function CommentSection({ eventId, isHost }) {
   const queryClient = useQueryClient()
   const { isAuthenticated, user } = useAuthStore()
   const [newComment, setNewComment] = useState('')
@@ -124,6 +124,17 @@ export default function CommentSection({ eventId }) {
     },
     onError: (error) => {
       toast.error(error.response?.data?.message || 'Failed to delete reply')
+    },
+  })
+
+  // Pin comment mutation
+  const pinCommentMutation = useMutation({
+    mutationFn: (commentId) => commentsAPI.pinComment(commentId),
+    onSuccess: (_, commentId) => {
+      queryClient.invalidateQueries(['eventComments', eventId])
+    },
+    onError: (error) => {
+      toast.error(error.response?.data?.message || 'Failed to pin comment')
     },
   })
 
@@ -314,7 +325,13 @@ export default function CommentSection({ eventId }) {
             const commentLink = !isDeleted && comment.memberId ? `/members/${comment.memberId}` : null
 
             return (
-              <div key={comment.id} className="group">
+              <div key={comment.id} className={`group ${comment.pinned ? 'bg-orange-50/60 rounded-xl p-3 -mx-1 border border-orange-100' : ''}`}>
+                {comment.pinned && (
+                  <div className="flex items-center gap-1 text-orange-500 text-xs font-semibold mb-2 ml-1">
+                    <Pin className="h-3 w-3" />
+                    <span>Pinned</span>
+                  </div>
+                )}
                 {/* Comment */}
                 <div className="flex gap-3">
                   {commentLink ? (
@@ -340,24 +357,36 @@ export default function CommentSection({ eventId }) {
                             {comment.edited && <span className="ml-1">(edited)</span>}
                           </p>
                         </div>
-                        {isAuthenticated && user?.id === comment.memberId && (
-                          <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                        <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                          {isHost && (
                             <button
-                              onClick={() => startEditingComment(comment)}
-                              className="p-1.5 text-gray-500 hover:text-purple-600 hover:bg-white rounded-lg transition-colors"
-                              title="Edit comment"
+                              onClick={() => pinCommentMutation.mutate(comment.id)}
+                              disabled={pinCommentMutation.isLoading}
+                              className={`p-1.5 rounded-lg transition-colors hover:bg-white ${comment.pinned ? 'text-orange-500 hover:text-orange-600' : 'text-gray-400 hover:text-orange-500'}`}
+                              title={comment.pinned ? 'Unpin comment' : 'Pin comment'}
                             >
-                              <Edit2 className="h-4 w-4" />
+                              <Pin className="h-3.5 w-3.5" />
                             </button>
-                            <button
-                              onClick={() => handleDeleteComment(comment.id)}
-                              className="p-1.5 text-gray-500 hover:text-red-600 hover:bg-white rounded-lg transition-colors"
-                              title="Delete comment"
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </button>
-                          </div>
-                        )}
+                          )}
+                          {isAuthenticated && user?.id === comment.memberId && (
+                            <>
+                              <button
+                                onClick={() => startEditingComment(comment)}
+                                className="p-1.5 text-gray-500 hover:text-purple-600 hover:bg-white rounded-lg transition-colors"
+                                title="Edit comment"
+                              >
+                                <Edit2 className="h-4 w-4" />
+                              </button>
+                              <button
+                                onClick={() => handleDeleteComment(comment.id)}
+                                className="p-1.5 text-gray-500 hover:text-red-600 hover:bg-white rounded-lg transition-colors"
+                                title="Delete comment"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </button>
+                            </>
+                          )}
+                        </div>
                       </div>
 
                       {editingComment === comment.id ? (

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -234,6 +234,9 @@ export const commentsAPI = {
   
   // Delete a reply
   deleteReply: (replyId) => api.delete(`/events/replies/${replyId}`),
+
+  // Toggle pin on a comment (host only)
+  pinComment: (commentId) => api.post(`/events/comments/${commentId}/pin`),
 }
 
 // Activity Types API

--- a/frontend/src/pages/EventDetailPage.jsx
+++ b/frontend/src/pages/EventDetailPage.jsx
@@ -2095,7 +2095,7 @@ export default function EventDetailPage() {
         {/* ============================================ */}
         {!isAccessDenied && (
           <div className="mt-4 lg:mt-6 pb-24 lg:pb-0">
-            <CommentSection eventId={id} />
+            <CommentSection eventId={id} isHost={isHost} />
           </div>
         )}
       </div>


### PR DESCRIPTION
- V55 migration adds pinned + pinned_at columns to event_comments
- Host-only toggle via POST /api/v1/events/comments/{id}/pin
- Pinned comments sorted to top (by pinnedAt desc), then rest by createdAt desc
- Max 3 pinned per event; exceeding returns 400
- Frontend: small pin icon on hover (host only), orange "Pinned" badge on pinned comments

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
