### PR TITLE
fix: resolve LazyInitializationException on Group read endpoints

### DIFF
--- a/backend/src/main/java/com/organiser/platform/service/GroupService.java
+++ b/backend/src/main/java/com/organiser/platform/service/GroupService.java
@@ -178,6 +178,7 @@ public class GroupService {
     /**
      * Get all groups a user is subscribed to.
      */
+    @Transactional(readOnly = true)
     @Cacheable(value = "groups", key = "'user_' + #memberId")
     public List<GroupDTO> getUserSubscribedGroups(Long memberId) {
         List<Subscription> subscriptions = subscriptionRepository.findByMemberId(memberId);
@@ -198,6 +199,7 @@ public class GroupService {
     /**
      * Get all groups organised by a specific user.
      */
+    @Transactional(readOnly = true)
     @Cacheable(value = "groups", key = "'organiser_' + #memberId")
     public List<GroupDTO> getUserOrganisedGroups(Long memberId) {
         List<Group> groups = groupRepository.findByPrimaryOrganiserId(memberId);
@@ -216,6 +218,7 @@ public class GroupService {
     /**
      * Get all public and active groups.
      */
+    @Transactional(readOnly = true)
     @Cacheable(value = "groups", key = "'public'")
     public List<GroupDTO> getAllPublicGroups() {
         List<Group> groups = groupRepository.findByIsPublicTrueAndActiveTrue();
@@ -237,6 +240,7 @@ public class GroupService {
     /**
      * Get group by ID with member count.
      */
+    @Transactional(readOnly = true)
     @Cacheable(value = "groups", key = "'group_' + #groupId")
     public GroupDTO getGroupById(Long groupId) {
         Group group = groupRepository.findById(groupId)


### PR DESCRIPTION
## Summary
- `getUserSubscribedGroups`, `getUserOrganisedGroups`, `getAllPublicGroups`, and `getGroupById` in `GroupService` were missing `@Transactional(readOnly = true)`
- Without a transaction, the Hibernate session closed after each repository call, so accessing lazy-loaded `primaryOrganiser` and `activity` proxies in `GroupDTO.fromEntity()` threw `LazyInitializationException` → 400 on `/my-groups` and `/my-organised-groups`

## Test plan
- [ ] `GET /api/v1/groups/my-organised-groups` returns 200 with group data
- [ ] `GET /api/v1/groups/my-groups` returns 200
- [ ] `GET /api/v1/groups/public` returns 200
- [ ] `GET /api/v1/groups/{id}` returns 200
- [ ] Organiser's group appears on home screen desktop tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)