### PR TITLE
fix: service worker returns shell fallback on cache miss

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -29,7 +29,13 @@ self.addEventListener('fetch', (event) => {
   if (url.pathname.startsWith('/api/')) return;
   if (url.protocol === 'chrome-extension:') return;
   event.respondWith(
-    fetch(request).catch(() => caches.match(request).then((cached) => cached || caches.match('/')))
+    fetch(request).catch(() =>
+      caches.match(request).then((cached) => {
+        if (cached) return cached;
+        if (request.mode === 'navigate') return caches.match('/');
+        return Response.error();
+      })
+    )
   );
 });
 

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -29,7 +29,7 @@ self.addEventListener('fetch', (event) => {
   if (url.pathname.startsWith('/api/')) return;
   if (url.protocol === 'chrome-extension:') return;
   event.respondWith(
-    fetch(request).catch(() => caches.match(request))
+    fetch(request).catch(() => caches.match(request).then((cached) => cached || caches.match('/')))
   );
 });
 


### PR DESCRIPTION
## Summary
- `caches.match()` returns `undefined` when a URL isn't in the cache; passing `undefined` to `respondWith()` throws `TypeError: Failed to convert value to 'Response'` and logs a network error for the request
- Fall back to the cached shell (`/`) so offline or failed navigations degrade gracefully

## Test plan
- [ ] No `TypeError: Failed to convert value to 'Response'` errors in console
- [ ] No `FetchEvent resulted in a network error` warnings for page routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)