### PR TITLE
fix: resolve LazyInitializationException on Review read endpoints

### DIFF
--- a/backend/src/main/java/com/organiser/platform/service/ReviewService.java
+++ b/backend/src/main/java/com/organiser/platform/service/ReviewService.java
@@ -49,6 +49,7 @@ public class ReviewService {
             EventParticipant.ParticipationStatus.ATTENDED
     );
     
+    @Transactional(readOnly = true)
     public List<PendingReviewDTO> getPendingReviews() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
@@ -105,6 +106,7 @@ public class ReviewService {
         eventParticipantRepository.save(ep);
     }
 
+    @Transactional(readOnly = true)
     public Page<EventReviewDTO> getMyReviews(int page, int size) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
@@ -117,18 +119,21 @@ public class ReviewService {
                 .map(EventReviewDTO::fromEntity);
     }
 
+    @Transactional(readOnly = true)
     public Page<EventReviewDTO> getEventReviews(Long eventId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         return eventReviewRepository.findByEventId(eventId, pageable)
                 .map(EventReviewDTO::fromEntity);
     }
     
+    @Transactional(readOnly = true)
     public Page<EventReviewDTO> getGroupReviews(Long groupId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         return eventReviewRepository.findByGroupId(groupId, pageable)
                 .map(EventReviewDTO::fromEntity);
     }
     
+    @Transactional(readOnly = true)
     public EventReviewDTO getMyReviewForEvent(Long eventId) {
         // Get authenticated user
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -29,7 +29,7 @@ self.addEventListener('fetch', (event) => {
   if (url.pathname.startsWith('/api/')) return;
   if (url.protocol === 'chrome-extension:') return;
   event.respondWith(
-    fetch(request).catch(() => caches.match(request))
+    fetch(request).catch(() => caches.match(request).then((cached) => cached || caches.match('/')))
   );
 });
 

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -29,7 +29,7 @@ self.addEventListener('fetch', (event) => {
   if (url.pathname.startsWith('/api/')) return;
   if (url.protocol === 'chrome-extension:') return;
   event.respondWith(
-    fetch(request).catch(() => caches.match(request).then((cached) => cached || caches.match('/')))
+    fetch(request).catch(() => caches.match(request))
   );
 });
 


### PR DESCRIPTION
## Summary
- `getPendingReviews`, `getMyReviews`, `getEventReviews`, `getGroupReviews`, and `getMyReviewForEvent` in `ReviewService` were missing `@Transactional(readOnly = true)`
- Without a transaction, the Hibernate session closed after each repository call, causing `LazyInitializationException` when `EventReviewDTO.fromEntity()` accessed lazy `event`, `member`, and `group` proxies → 400 on `/groups/{id}/reviews` and related endpoints

## Test plan
- [ ] `GET /api/v1/groups/4/reviews` returns 200
- [ ] `GET /api/v1/events/{id}/reviews` returns 200
- [ ] `GET /api/v1/reviews/my-reviews` returns 200
- [ ] Pending reviews load without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)