### PR TITLE
fix: add @Transactional(readOnly=true) to getBannedMembers

### DIFF
--- a/backend/src/main/java/com/organiser/platform/repository/BannedMemberRepository.java
+++ b/backend/src/main/java/com/organiser/platform/repository/BannedMemberRepository.java
@@ -25,7 +25,8 @@ public interface BannedMemberRepository extends JpaRepository<BannedMember, Long
     /**
      * Get all banned members for a group
      */
-    List<BannedMember> findByGroupIdOrderByBannedAtDesc(Long groupId);
+    @Query("SELECT bm FROM BannedMember bm JOIN FETCH bm.member JOIN FETCH bm.bannedBy WHERE bm.group.id = :groupId ORDER BY bm.bannedAt DESC")
+    List<BannedMember> findByGroupIdOrderByBannedAtDesc(@Param("groupId") Long groupId);
     
     /**
      * Get all groups a member is banned from

--- a/backend/src/main/java/com/organiser/platform/service/GroupService.java
+++ b/backend/src/main/java/com/organiser/platform/service/GroupService.java
@@ -523,6 +523,7 @@ public class GroupService {
      * Get all banned members for a group (organiser only).
      * Email addresses are NEVER exposed in member lists for privacy protection (Meetup.com approach).
      */
+    @Transactional(readOnly = true)
     public List<com.organiser.platform.dto.MemberDTO> getBannedMembers(Long groupId, Long organiserId) {
         // Verify group exists
         Group group = groupRepository.findById(groupId)


### PR DESCRIPTION
## Summary
- `getBannedMembers` in `GroupService` was missing `@Transactional(readOnly = true)`
- Accesses lazy proxies `BannedMember.member`, `BannedMember.bannedBy`, and `group.getPrimaryOrganiser()` — all broken by `open-in-view=false`

## Test plan
- [ ] `GET /api/v1/groups/{id}/banned-members` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)