### PR TITLE
feat: offline mode for event detail page

### DIFF
--- a/backend/src/main/java/com/organiser/platform/config/SecurityConfig.java
+++ b/backend/src/main/java/com/organiser/platform/config/SecurityConfig.java
@@ -114,6 +114,7 @@ public class SecurityConfig {
                         
                         // Event write operations - require authentication
                         .requestMatchers(
+                                new AntPathRequestMatcher("/api/v1/events/*/offline-bundle", "GET"),
                                 new AntPathRequestMatcher("/api/v1/events", "POST"),
                                 new AntPathRequestMatcher("/api/v1/events/*", "PUT"),
                                 new AntPathRequestMatcher("/api/v1/events/*", "DELETE"),

--- a/backend/src/main/java/com/organiser/platform/controller/EventController.java
+++ b/backend/src/main/java/com/organiser/platform/controller/EventController.java
@@ -3,8 +3,9 @@ package com.organiser.platform.controller;
 import com.organiser.platform.dto.CalendarEventDTO;
 import com.organiser.platform.dto.CreateEventRequest;
 import com.organiser.platform.dto.EventDTO;
-import com.organiser.platform.dto.JoinEventRequest;
 import com.organiser.platform.dto.EventSearchResponse;
+import com.organiser.platform.dto.JoinEventRequest;
+import com.organiser.platform.dto.OfflineBundleDTO;
 import com.organiser.platform.service.EventService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -218,6 +219,15 @@ public class EventController {
         return ResponseEntity.ok(eventService.getEventParticipants(id, requesterId));
     }
     
+    @GetMapping("/{id}/offline-bundle")
+    public ResponseEntity<OfflineBundleDTO> getOfflineBundle(
+            @PathVariable Long id,
+            Authentication authentication
+    ) {
+        Long memberId = getUserIdFromAuth(authentication);
+        return ResponseEntity.ok(eventService.buildOfflineBundle(id, memberId));
+    }
+
     @GetMapping("/public/{id}/calendar")
     public ResponseEntity<CalendarEventDTO> getCalendarData(
             @PathVariable Long id,

--- a/backend/src/main/java/com/organiser/platform/dto/OfflineBundleDTO.java
+++ b/backend/src/main/java/com/organiser/platform/dto/OfflineBundleDTO.java
@@ -1,0 +1,20 @@
+package com.organiser.platform.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfflineBundleDTO {
+    private EventDTO event;
+    private List<OfflineContactDTO> contacts;
+    private String viewerRole; // "host" or "attendee"
+    private Instant bundledAt;
+}

--- a/backend/src/main/java/com/organiser/platform/dto/OfflineContactDTO.java
+++ b/backend/src/main/java/com/organiser/platform/dto/OfflineContactDTO.java
@@ -1,0 +1,19 @@
+package com.organiser.platform.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfflineContactDTO {
+    private Long memberId;
+    private String memberName;
+    private String profilePhotoUrl;
+    private List<ContactInfoDTO> contacts;
+}

--- a/backend/src/main/java/com/organiser/platform/service/EventService.java
+++ b/backend/src/main/java/com/organiser/platform/service/EventService.java
@@ -1417,6 +1417,8 @@ public class EventService {
 
         List<OfflineContactDTO> contacts = new ArrayList<>();
 
+        // TODO: getVisibleContacts performs per-member DB queries (subscriptions + participations).
+        //  For large groups this is N+1. Optimise by bulk-fetching shared-group flags when needed.
         if (isHost) {
             for (EventParticipant participant : event.getParticipants()) {
                 Member member = participant.getMember();

--- a/backend/src/main/java/com/organiser/platform/service/EventService.java
+++ b/backend/src/main/java/com/organiser/platform/service/EventService.java
@@ -4,8 +4,11 @@ package com.organiser.platform.service;
 // IMPORTS
 // ============================================================
 import com.organiser.platform.dto.CalendarEventDTO;
+import com.organiser.platform.dto.ContactInfoDTO;
 import com.organiser.platform.dto.CreateEventRequest;
 import com.organiser.platform.dto.EventDTO;
+import com.organiser.platform.dto.OfflineBundleDTO;
+import com.organiser.platform.dto.OfflineContactDTO;
 import com.organiser.platform.dto.TransportLegDTO;
 import com.organiser.platform.exception.AlreadyRegisteredException;
 import com.organiser.platform.model.*;
@@ -13,6 +16,7 @@ import java.math.BigDecimal;
 import com.organiser.platform.repository.*;
 import com.organiser.platform.util.EventTimingUtils;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -66,6 +70,7 @@ public class EventService {
     private final WebPushService webPushService;
     private final EmailService emailService;
     private final GroupRatingSummaryRepository groupRatingSummaryRepository;
+    private final ContactInfoService contactInfoService;
     
     // ============================================================
     // PUBLIC METHODS - Event CRUD Operations
@@ -1380,6 +1385,79 @@ public class EventService {
                           && p.getStatus() != EventParticipant.ParticipationStatus.WAITLISTED)
                 .mapToInt(p -> 1 + (p.getGuestCount() != null ? p.getGuestCount() : 0))
                 .sum();
+    }
+
+    // ============================================================
+    // OFFLINE BUNDLE
+    // ============================================================
+
+    /**
+     * Build a read-only offline snapshot of an event for a registered participant or host.
+     * - Attendees receive host contact info.
+     * - Hosts receive all attendee contact info.
+     */
+    @Transactional(readOnly = true)
+    public OfflineBundleDTO buildOfflineBundle(Long eventId, Long requesterId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new RuntimeException("Event not found"));
+
+        boolean isHost = event.getHostMember() != null &&
+                event.getHostMember().getId().equals(requesterId);
+
+        boolean isParticipant = event.getParticipants().stream()
+                .anyMatch(p -> p.getMember().getId().equals(requesterId) &&
+                        (p.getStatus() == EventParticipant.ParticipationStatus.REGISTERED ||
+                         p.getStatus() == EventParticipant.ParticipationStatus.CONFIRMED));
+
+        if (!isHost && !isParticipant) {
+            throw new org.springframework.security.access.AccessDeniedException("Not a participant of this event");
+        }
+
+        EventDTO eventDto = getEventById(eventId, requesterId);
+
+        List<OfflineContactDTO> contacts = new ArrayList<>();
+
+        if (isHost) {
+            for (EventParticipant participant : event.getParticipants()) {
+                Member member = participant.getMember();
+                if (!member.getId().equals(requesterId) &&
+                        Boolean.TRUE.equals(member.getActive()) &&
+                        participant.getStatus() != EventParticipant.ParticipationStatus.CANCELLED &&
+                        participant.getStatus() != EventParticipant.ParticipationStatus.WAITLISTED) {
+                    List<ContactInfoDTO> memberContacts =
+                            contactInfoService.getVisibleContacts(member.getId(), requesterId);
+                    if (!memberContacts.isEmpty()) {
+                        contacts.add(OfflineContactDTO.builder()
+                                .memberId(member.getId())
+                                .memberName(member.getDisplayName())
+                                .profilePhotoUrl(member.getProfilePhotoUrl())
+                                .contacts(memberContacts)
+                                .build());
+                    }
+                }
+            }
+        } else {
+            if (event.getHostMember() != null && Boolean.TRUE.equals(event.getHostMember().getActive())) {
+                Long hostId = event.getHostMember().getId();
+                List<ContactInfoDTO> hostContacts =
+                        contactInfoService.getVisibleContacts(hostId, requesterId);
+                if (!hostContacts.isEmpty()) {
+                    contacts.add(OfflineContactDTO.builder()
+                            .memberId(hostId)
+                            .memberName(event.getHostMember().getDisplayName())
+                            .profilePhotoUrl(event.getHostMember().getProfilePhotoUrl())
+                            .contacts(hostContacts)
+                            .build());
+                }
+            }
+        }
+
+        return OfflineBundleDTO.builder()
+                .event(eventDto)
+                .contacts(contacts)
+                .viewerRole(isHost ? "host" : "attendee")
+                .bundledAt(Instant.now())
+                .build();
     }
 
     // ============================================================

--- a/frontend/src/components/OfflineEventView.jsx
+++ b/frontend/src/components/OfflineEventView.jsx
@@ -1,8 +1,8 @@
 import { MapPin, Calendar, Mountain, WifiOff, ArrowLeft } from 'lucide-react'
 import { format, formatDistanceToNow } from 'date-fns'
 
-export default function OfflineEventView({ bundle, savedAt, onGoBack }) {
-  const { event, contacts, viewerRole } = bundle
+export default function OfflineEventView({ bundle = {}, savedAt, onGoBack }) {
+  const { event = {}, contacts = [], viewerRole } = bundle
   const eventDate = event.eventDate ? new Date(event.eventDate) : null
 
   return (
@@ -86,20 +86,29 @@ export default function OfflineEventView({ bundle, savedAt, onGoBack }) {
                 >
                   <p className="font-bold text-gray-900 mb-2">{person.memberName}</p>
                   <div className="space-y-1.5">
-                    {person.contacts.map((c, i) => (
-                      <a
-                        key={i}
-                        href={c.deepLink || undefined}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-2 text-sm text-purple-700 hover:underline"
-                      >
-                        <span className="font-medium capitalize">
-                          {c.displayLabel || c.platform.replace('_', ' ').toLowerCase()}:
-                        </span>
-                        <span>{c.contactValue}</span>
-                      </a>
-                    ))}
+                    {person.contacts.map((c, i) =>
+                      c.deepLink ? (
+                        <a
+                          key={i}
+                          href={c.deepLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-2 text-sm text-purple-700 hover:underline"
+                        >
+                          <span className="font-medium capitalize">
+                            {c.displayLabel || c.platform.replace('_', ' ').toLowerCase()}:
+                          </span>
+                          <span>{c.contactValue}</span>
+                        </a>
+                      ) : (
+                        <div key={i} className="flex items-center gap-2 text-sm text-gray-700">
+                          <span className="font-medium capitalize">
+                            {c.displayLabel || c.platform.replace('_', ' ').toLowerCase()}:
+                          </span>
+                          <span>{c.contactValue}</span>
+                        </div>
+                      )
+                    )}
                   </div>
                 </div>
               ))}

--- a/frontend/src/components/OfflineEventView.jsx
+++ b/frontend/src/components/OfflineEventView.jsx
@@ -1,0 +1,116 @@
+import { MapPin, Calendar, Mountain, WifiOff, ArrowLeft } from 'lucide-react'
+import { format, formatDistanceToNow } from 'date-fns'
+
+export default function OfflineEventView({ bundle, savedAt, onGoBack }) {
+  const { event, contacts, viewerRole } = bundle
+  const eventDate = event.eventDate ? new Date(event.eventDate) : null
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Offline banner */}
+      <div className="bg-amber-50 border-b border-amber-200 px-4 py-2.5 flex items-center gap-2 text-sm text-amber-800">
+        <WifiOff className="h-4 w-4 flex-shrink-0" />
+        <span>
+          Offline · saved{' '}
+          {savedAt ? formatDistanceToNow(savedAt, { addSuffix: true }) : ''}
+        </span>
+      </div>
+
+      <div className="max-w-2xl mx-auto px-4 py-5 pb-10 space-y-5">
+        {/* Back button */}
+        <button
+          onClick={onGoBack}
+          className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800 transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </button>
+
+        {/* Title */}
+        <h1 className="text-2xl font-extrabold bg-gradient-to-r from-purple-600 via-pink-600 to-orange-500 bg-clip-text text-transparent leading-tight">
+          {event.title}
+        </h1>
+
+        {/* Date/Time */}
+        {eventDate && (
+          <div className="flex items-center gap-3 text-gray-700">
+            <Calendar className="h-5 w-5 text-purple-500 flex-shrink-0" />
+            <div>
+              <p className="font-semibold">{format(eventDate, 'EEEE, d MMMM yyyy')}</p>
+              <p className="text-sm text-gray-500">{format(eventDate, 'h:mm a')}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Location */}
+        {event.location && (
+          <div className="flex items-start gap-3 text-gray-700">
+            <MapPin className="h-5 w-5 text-pink-500 flex-shrink-0 mt-0.5" />
+            <p className="font-medium">{event.location}</p>
+          </div>
+        )}
+
+        {/* Activity / Difficulty */}
+        {(event.activityTypeName || event.difficultyLevel) && (
+          <div className="flex items-center gap-3 text-gray-700">
+            <Mountain className="h-5 w-5 text-orange-500 flex-shrink-0" />
+            <p className="font-medium">
+              {event.activityTypeName}
+              {event.difficultyLevel && ` · ${event.difficultyLevel}`}
+              {event.distanceKm && ` · ${event.distanceKm} km`}
+            </p>
+          </div>
+        )}
+
+        {/* Description */}
+        {event.description && (
+          <div>
+            <h2 className="text-xs font-bold text-gray-400 uppercase tracking-wide mb-2">About</h2>
+            <p className="text-gray-800 text-sm leading-relaxed whitespace-pre-wrap">
+              {event.description}
+            </p>
+          </div>
+        )}
+
+        {/* Contacts */}
+        {contacts.length > 0 && (
+          <div>
+            <h2 className="text-xs font-bold text-gray-400 uppercase tracking-wide mb-3">
+              {viewerRole === 'host' ? 'Attendee Contacts' : 'Host Contact'}
+            </h2>
+            <div className="space-y-3">
+              {contacts.map((person) => (
+                <div
+                  key={person.memberId}
+                  className="bg-white rounded-xl p-4 border border-gray-100 shadow-sm"
+                >
+                  <p className="font-bold text-gray-900 mb-2">{person.memberName}</p>
+                  <div className="space-y-1.5">
+                    {person.contacts.map((c, i) => (
+                      <a
+                        key={i}
+                        href={c.deepLink || undefined}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-2 text-sm text-purple-700 hover:underline"
+                      >
+                        <span className="font-medium capitalize">
+                          {c.displayLabel || c.platform.replace('_', ' ').toLowerCase()}:
+                        </span>
+                        <span>{c.contactValue}</span>
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {contacts.length === 0 && (
+          <p className="text-sm text-gray-400 italic">No contact info available offline.</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/OfflineSaveButton.jsx
+++ b/frontend/src/components/OfflineSaveButton.jsx
@@ -1,0 +1,39 @@
+import { Download, Check, RefreshCw } from 'lucide-react'
+import { formatDistanceToNow } from 'date-fns'
+
+export default function OfflineSaveButton({ isSaved, savedAt, isSaving, onSave }) {
+  if (isSaving) {
+    return (
+      <button
+        disabled
+        className="flex items-center gap-1.5 text-xs text-gray-500 py-2 px-3 border border-gray-200 rounded-lg bg-white"
+      >
+        <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+        Saving...
+      </button>
+    )
+  }
+
+  if (isSaved && savedAt) {
+    return (
+      <button
+        onClick={onSave}
+        className="flex items-center gap-1.5 text-xs text-green-700 py-2 px-3 border border-green-200 bg-green-50 rounded-lg hover:bg-green-100 transition-colors"
+        title="Tap to refresh offline copy"
+      >
+        <Check className="h-3.5 w-3.5" />
+        Saved · {formatDistanceToNow(savedAt, { addSuffix: true })}
+      </button>
+    )
+  }
+
+  return (
+    <button
+      onClick={onSave}
+      className="flex items-center gap-1.5 text-xs text-gray-700 py-2 px-3 border border-gray-300 bg-white rounded-lg hover:bg-gray-50 transition-colors"
+    >
+      <Download className="h-3.5 w-3.5" />
+      Save offline
+    </button>
+  )
+}

--- a/frontend/src/hooks/useOfflineCache.js
+++ b/frontend/src/hooks/useOfflineCache.js
@@ -1,17 +1,27 @@
 import { useState, useEffect, useCallback } from 'react'
 import { saveOfflineBundle, loadOfflineBundle } from '../lib/offlineCache'
 import { eventsAPI } from '../lib/api'
+import { useAuthStore } from '../store/authStore'
 import toast from 'react-hot-toast'
 
 export function useOfflineCache(eventId) {
+  const { user } = useAuthStore()
+  const userId = user?.id ?? null
+
   const [isSaved, setIsSaved] = useState(false)
   const [savedAt, setSavedAt] = useState(null)
   const [isSaving, setIsSaving] = useState(false)
   const [cachedBundle, setCachedBundle] = useState(null)
 
   useEffect(() => {
-    if (!eventId) return
-    loadOfflineBundle(eventId)
+    // Reset state immediately so the previous event's data never bleeds through
+    setIsSaved(false)
+    setSavedAt(null)
+    setCachedBundle(null)
+
+    if (!eventId || !userId) return
+
+    loadOfflineBundle(eventId, userId)
       .then((record) => {
         if (record) {
           setIsSaved(true)
@@ -20,15 +30,15 @@ export function useOfflineCache(eventId) {
         }
       })
       .catch(() => {})
-  }, [eventId])
+  }, [eventId, userId])
 
   const save = useCallback(async () => {
-    if (isSaving) return
+    if (isSaving || !userId) return
     setIsSaving(true)
     try {
       const response = await eventsAPI.getOfflineBundle(eventId)
       const bundle = response.data
-      await saveOfflineBundle(eventId, bundle)
+      await saveOfflineBundle(eventId, userId, bundle)
       setIsSaved(true)
       setSavedAt(new Date())
       setCachedBundle(bundle)
@@ -38,7 +48,7 @@ export function useOfflineCache(eventId) {
     } finally {
       setIsSaving(false)
     }
-  }, [eventId, isSaving])
+  }, [eventId, userId, isSaving])
 
   return { isSaved, savedAt, isSaving, cachedBundle, save }
 }

--- a/frontend/src/hooks/useOfflineCache.js
+++ b/frontend/src/hooks/useOfflineCache.js
@@ -1,0 +1,44 @@
+import { useState, useEffect, useCallback } from 'react'
+import { saveOfflineBundle, loadOfflineBundle } from '../lib/offlineCache'
+import { eventsAPI } from '../lib/api'
+import toast from 'react-hot-toast'
+
+export function useOfflineCache(eventId) {
+  const [isSaved, setIsSaved] = useState(false)
+  const [savedAt, setSavedAt] = useState(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [cachedBundle, setCachedBundle] = useState(null)
+
+  useEffect(() => {
+    if (!eventId) return
+    loadOfflineBundle(eventId)
+      .then((record) => {
+        if (record) {
+          setIsSaved(true)
+          setSavedAt(new Date(record.savedAt))
+          setCachedBundle(record.bundle)
+        }
+      })
+      .catch(() => {})
+  }, [eventId])
+
+  const save = useCallback(async () => {
+    if (isSaving) return
+    setIsSaving(true)
+    try {
+      const response = await eventsAPI.getOfflineBundle(eventId)
+      const bundle = response.data
+      await saveOfflineBundle(eventId, bundle)
+      setIsSaved(true)
+      setSavedAt(new Date())
+      setCachedBundle(bundle)
+      toast.success('Event saved for offline access')
+    } catch {
+      toast.error('Failed to save offline')
+    } finally {
+      setIsSaving(false)
+    }
+  }, [eventId, isSaving])
+
+  return { isSaved, savedAt, isSaving, cachedBundle, save }
+}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -210,6 +210,8 @@ export const eventsAPI = {
   unmarkNoShow: (eventId, memberId) => api.delete(`/events/${eventId}/participants/${memberId}/no-show`),
 
   getCalendarData: (id) => api.get(`/events/public/${id}/calendar`),
+
+  getOfflineBundle: (id) => api.get(`/events/${id}/offline-bundle`),
 }
 
 // Comments API

--- a/frontend/src/lib/offlineCache.js
+++ b/frontend/src/lib/offlineCache.js
@@ -1,0 +1,50 @@
+const DB_NAME = 'outmeets-offline'
+const STORE_NAME = 'events'
+const DB_VERSION = 1
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    request.onupgradeneeded = (event) => {
+      const db = event.target.result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'eventId' })
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+}
+
+export async function saveOfflineBundle(eventId, bundle) {
+  const db = await openDB()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    store.put({ eventId: String(eventId), bundle, savedAt: new Date().toISOString() })
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+  })
+}
+
+export async function loadOfflineBundle(eventId) {
+  const db = await openDB()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly')
+    const store = tx.objectStore(STORE_NAME)
+    const request = store.get(String(eventId))
+    request.onsuccess = () => resolve(request.result || null)
+    request.onerror = () => reject(request.error)
+  })
+}
+
+export async function clearOfflineBundle(eventId) {
+  const db = await openDB()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    store.delete(String(eventId))
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+  })
+}

--- a/frontend/src/lib/offlineCache.js
+++ b/frontend/src/lib/offlineCache.js
@@ -2,13 +2,17 @@ const DB_NAME = 'outmeets-offline'
 const STORE_NAME = 'events'
 const DB_VERSION = 1
 
+function buildKey(eventId, userId) {
+  return `${String(userId)}::${String(eventId)}`
+}
+
 function openDB() {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION)
     request.onupgradeneeded = (event) => {
       const db = event.target.result
       if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME, { keyPath: 'eventId' })
+        db.createObjectStore(STORE_NAME, { keyPath: 'cacheKey' })
       }
     }
     request.onsuccess = () => resolve(request.result)
@@ -16,34 +20,37 @@ function openDB() {
   })
 }
 
-export async function saveOfflineBundle(eventId, bundle) {
+export async function saveOfflineBundle(eventId, userId, bundle) {
   const db = await openDB()
+  const cacheKey = buildKey(eventId, userId)
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite')
     const store = tx.objectStore(STORE_NAME)
-    store.put({ eventId: String(eventId), bundle, savedAt: new Date().toISOString() })
+    store.put({ cacheKey, bundle, savedAt: new Date().toISOString() })
     tx.oncomplete = () => resolve()
     tx.onerror = () => reject(tx.error)
   })
 }
 
-export async function loadOfflineBundle(eventId) {
+export async function loadOfflineBundle(eventId, userId) {
   const db = await openDB()
+  const cacheKey = buildKey(eventId, userId)
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readonly')
     const store = tx.objectStore(STORE_NAME)
-    const request = store.get(String(eventId))
+    const request = store.get(cacheKey)
     request.onsuccess = () => resolve(request.result || null)
     request.onerror = () => reject(request.error)
   })
 }
 
-export async function clearOfflineBundle(eventId) {
+export async function clearOfflineBundle(eventId, userId) {
   const db = await openDB()
+  const cacheKey = buildKey(eventId, userId)
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite')
     const store = tx.objectStore(STORE_NAME)
-    store.delete(String(eventId))
+    store.delete(cacheKey)
     tx.oncomplete = () => resolve()
     tx.onerror = () => reject(tx.error)
   })

--- a/frontend/src/pages/EventDetailPage.jsx
+++ b/frontend/src/pages/EventDetailPage.jsx
@@ -739,13 +739,16 @@ export default function EventDetailPage() {
         )}
 
         {/* 1-hour pre-event offline prompt */}
-        {isAuthenticated && (hasJoined || isHost) && !isSaved && !isPastEvent && eventStart &&
-          eventStart - new Date() <= 60 * 60 * 1000 && eventStart - new Date() > 0 && (
+        {(() => {
+          const msUntilStart = eventStart ? eventStart - new Date() : null
+          return isAuthenticated && (hasJoined || isHost) && !isSaved && !isPastEvent &&
+            msUntilStart !== null && msUntilStart <= 60 * 60 * 1000 && msUntilStart > 0 && (
           <div className="lg:hidden mb-4 p-3 bg-amber-50 border border-amber-200 rounded-xl flex items-center justify-between gap-3">
             <p className="text-xs text-amber-800 font-medium">Going remote? Save this event for offline access.</p>
             <OfflineSaveButton isSaved={isSaved} savedAt={savedAt} isSaving={isSaving} onSave={save} />
           </div>
-        )}
+          )
+        })()}
 
         {/* ============================================ */}
         {/* MOBILE STICKY ACTION BAR - Bottom of screen */}
@@ -895,6 +898,9 @@ export default function EventDetailPage() {
                         Manage
                       </button>
                     </div>
+                    {!isPastEvent && (
+                      <OfflineSaveButton isSaved={isSaved} savedAt={savedAt} isSaving={isSaving} onSave={save} />
+                    )}
                   </div>
                 )}
               </div>

--- a/frontend/src/pages/EventDetailPage.jsx
+++ b/frontend/src/pages/EventDetailPage.jsx
@@ -22,6 +22,9 @@ import InviteMembersModal from '../components/InviteMembersModal'
 import { useFeatureFlags } from '../contexts/FeatureFlagContext'
 import { useIsIOS } from '../hooks/useIsIOS'
 import { useSmartBack } from '../hooks/useSmartBack'
+import { useOfflineCache } from '../hooks/useOfflineCache'
+import OfflineSaveButton from '../components/OfflineSaveButton'
+import OfflineEventView from '../components/OfflineEventView'
 import {
   trackEventViewed,
   trackJoinEventClicked,
@@ -81,6 +84,20 @@ export default function EventDetailPage() {
   const [showInviteModal, setShowInviteModal] = useState(false)
   const [showFlyerModal, setShowFlyerModal] = useState(false)
   const [noShowLoadingIds, setNoShowLoadingIds] = useState(new Set())
+
+  // Offline mode
+  const [isOnline, setIsOnline] = useState(navigator.onLine)
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true)
+    const handleOffline = () => setIsOnline(false)
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [])
+  const { isSaved, savedAt, isSaving, cachedBundle, save } = useOfflineCache(id)
 
   // ============================================
   // DATA FETCHING - React Query hooks
@@ -495,6 +512,11 @@ export default function EventDetailPage() {
     )
   }
 
+  // Offline mode: show cached bundle when there is no network connection
+  if (!isOnline && cachedBundle) {
+    return <OfflineEventView bundle={cachedBundle} savedAt={savedAt} onGoBack={goBack} />
+  }
+
   // Check if event is in the past
   // Parse dates from backend (Instant/UTC timestamps)
   const eventStart = event?.eventDate ? new Date(event.eventDate) : null
@@ -716,6 +738,15 @@ export default function EventDetailPage() {
         </div>
         )}
 
+        {/* 1-hour pre-event offline prompt */}
+        {isAuthenticated && (hasJoined || isHost) && !isSaved && !isPastEvent && eventStart &&
+          eventStart - new Date() <= 60 * 60 * 1000 && eventStart - new Date() > 0 && (
+          <div className="lg:hidden mb-4 p-3 bg-amber-50 border border-amber-200 rounded-xl flex items-center justify-between gap-3">
+            <p className="text-xs text-amber-800 font-medium">Going remote? Save this event for offline access.</p>
+            <OfflineSaveButton isSaved={isSaved} savedAt={savedAt} isSaving={isSaving} onSave={save} />
+          </div>
+        )}
+
         {/* ============================================ */}
         {/* MOBILE STICKY ACTION BAR - Bottom of screen */}
         {/* ============================================ */}
@@ -812,23 +843,28 @@ export default function EventDetailPage() {
                 </div>
                 {isHost ? (
                   // Host cannot leave - they're essential to the event
-                  <div className="flex items-center gap-2">
-                    <button
-                      onClick={() => {
-                        openGuestModal(displayGuestCount)
-                      }}
-                      className="flex-1 py-2.5 px-3 bg-white border-2 border-purple-200 text-purple-600 font-bold rounded-lg hover:border-purple-400 hover:bg-purple-50 transition-all flex items-center justify-center gap-2 text-sm"
-                    >
-                      <Users className="h-4 w-4" />
-                      Guests
-                    </button>
-                    <button
-                      onClick={() => setIsManageOpen(true)}
-                      className="flex-1 py-2.5 px-3 bg-gradient-to-r from-purple-600 to-pink-600 text-white font-bold rounded-lg hover:shadow-lg transition-all flex items-center justify-center gap-2 text-sm"
-                    >
-                      <Edit className="h-4 w-4" />
-                      Manage
-                    </button>
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => {
+                          openGuestModal(displayGuestCount)
+                        }}
+                        className="flex-1 py-2.5 px-3 bg-white border-2 border-purple-200 text-purple-600 font-bold rounded-lg hover:border-purple-400 hover:bg-purple-50 transition-all flex items-center justify-center gap-2 text-sm"
+                      >
+                        <Users className="h-4 w-4" />
+                        Guests
+                      </button>
+                      <button
+                        onClick={() => setIsManageOpen(true)}
+                        className="flex-1 py-2.5 px-3 bg-gradient-to-r from-purple-600 to-pink-600 text-white font-bold rounded-lg hover:shadow-lg transition-all flex items-center justify-center gap-2 text-sm"
+                      >
+                        <Edit className="h-4 w-4" />
+                        Manage
+                      </button>
+                    </div>
+                    {!isPastEvent && (
+                      <OfflineSaveButton isSaved={isSaved} savedAt={savedAt} isSaving={isSaving} onSave={save} />
+                    )}
                   </div>
                 ) : (
                   // Organiser but not host - can manage guests and leave
@@ -903,6 +939,10 @@ export default function EventDetailPage() {
                   </div>
                   <ChevronRight className="h-4 w-4 text-green-500 flex-shrink-0" />
                 </button>
+                {/* Offline save */}
+                {!isPastEvent && (
+                  <OfflineSaveButton isSaved={isSaved} savedAt={savedAt} isSaving={isSaving} onSave={save} />
+                )}
                 {/* Actions row */}
                 <div className="flex items-center gap-2">
                   <button


### PR DESCRIPTION
## Summary

- **Backend**: New `GET /api/v1/events/{id}/offline-bundle` endpoint returns a role-aware snapshot — attendees get the host card with contact info, hosts get the attendee list with contacts. Access is restricted to confirmed participants/hosts via JWT. SecurityConfig updated.
- **Frontend**: `offlineCache.js` (IndexedDB store), `useOfflineCache` hook, `OfflineSaveButton` component (Save offline → Saving... → Saved · X ago → tap to refresh), `OfflineEventView` read-only render with an amber offline banner.
- **EventDetailPage (mobile)**: Save button added to attendee and host action bars. 1-hour pre-event prompt banner shown when event starts within the hour and not yet saved. When device has no network and a bundle exists, renders `OfflineEventView` instead of the normal page.

## What's cached

| Role | Cached data |
|---|---|
| Attendee | Event details + host card contacts |
| Host | Event details + all attendee contacts (same visibility rules as live page) |

## Test plan

- [ ] As an attendee on a future event, tap "Save offline" — toast confirms, button shows "Saved · just now"
- [ ] Toggle device to airplane mode, navigate to `/events/{id}` — offline view renders with amber banner
- [ ] Offline view shows: title, date, location, description, activity, host contact info
- [ ] As a host, save offline — offline view shows attendee contacts instead
- [ ] Navigate to event within 1 hour of start (not yet saved) — prompt banner appears
- [ ] Past events and non-participants do not show the save button

🤖 Generated with [Claude Code](https://claude.com/claude-code)