### PR TITLE
fix: explicitly save reviewPromptSent flag to prevent duplicate review emails

### DIFF
--- a/backend/src/main/java/com/organiser/platform/scheduler/ReviewNotificationScheduler.java
+++ b/backend/src/main/java/com/organiser/platform/scheduler/ReviewNotificationScheduler.java
@@ -3,6 +3,7 @@ package com.organiser.platform.scheduler;
 import com.organiser.platform.model.EventParticipant;
 import com.organiser.platform.repository.EventParticipantRepository;
 import com.organiser.platform.service.EmailService;
+import com.organiser.platform.service.ReviewPromptFlagService;
 import com.organiser.platform.service.WebPushService;
 import com.organiser.platform.util.EventTimingUtils;
 import lombok.RequiredArgsConstructor;
@@ -30,9 +31,10 @@ public class ReviewNotificationScheduler {
     private final EventParticipantRepository eventParticipantRepository;
     private final WebPushService webPushService;
     private final EmailService emailService;
+    private final ReviewPromptFlagService reviewPromptFlagService;
 
     @Scheduled(cron = "0 0 10 * * *") // 10:00 AM UTC daily
-    @Transactional
+    @Transactional(readOnly = true)
     public void sendReviewPrompts() {
         log.info("Review prompt scheduler started");
 
@@ -56,8 +58,7 @@ public class ReviewNotificationScheduler {
             // Precise time window: event must have ended at least 24h ago and no more than 30 days ago
             long hoursElapsed = ChronoUnit.HOURS.between(eventEnd, now);
             if (hoursElapsed > 30 * 24) {
-                ep.setReviewPromptSent(true); // expired — stop revisiting on future runs
-                eventParticipantRepository.save(ep);
+                reviewPromptFlagService.markPromptSent(ep); // expired — stop revisiting on future runs
                 skipped++;
                 continue;
             }
@@ -73,8 +74,7 @@ public class ReviewNotificationScheduler {
                     ? ep.getEvent().getHostMember().getId() : null;
 
             if (memberId.equals(organiserId) || memberId.equals(hostMemberId)) {
-                ep.setReviewPromptSent(true); // mark so we don't revisit on future runs
-                eventParticipantRepository.save(ep);
+                reviewPromptFlagService.markPromptSent(ep); // mark so we don't revisit on future runs
                 skipped++;
                 continue;
             }
@@ -96,8 +96,9 @@ public class ReviewNotificationScheduler {
                     ep.getEvent().getId()
             );
 
-            ep.setReviewPromptSent(true);
-            eventParticipantRepository.save(ep);
+            // Commit the flag in its own transaction immediately after sending so it
+            // survives any subsequent failure in this batch run.
+            reviewPromptFlagService.markPromptSent(ep);
             sent++;
         }
 

--- a/backend/src/main/java/com/organiser/platform/scheduler/ReviewNotificationScheduler.java
+++ b/backend/src/main/java/com/organiser/platform/scheduler/ReviewNotificationScheduler.java
@@ -57,6 +57,7 @@ public class ReviewNotificationScheduler {
             long hoursElapsed = ChronoUnit.HOURS.between(eventEnd, now);
             if (hoursElapsed > 30 * 24) {
                 ep.setReviewPromptSent(true); // expired — stop revisiting on future runs
+                eventParticipantRepository.save(ep);
                 skipped++;
                 continue;
             }
@@ -73,6 +74,7 @@ public class ReviewNotificationScheduler {
 
             if (memberId.equals(organiserId) || memberId.equals(hostMemberId)) {
                 ep.setReviewPromptSent(true); // mark so we don't revisit on future runs
+                eventParticipantRepository.save(ep);
                 skipped++;
                 continue;
             }
@@ -95,6 +97,7 @@ public class ReviewNotificationScheduler {
             );
 
             ep.setReviewPromptSent(true);
+            eventParticipantRepository.save(ep);
             sent++;
         }
 

--- a/backend/src/main/java/com/organiser/platform/service/ReviewPromptFlagService.java
+++ b/backend/src/main/java/com/organiser/platform/service/ReviewPromptFlagService.java
@@ -1,0 +1,28 @@
+package com.organiser.platform.service;
+
+import com.organiser.platform.model.EventParticipant;
+import com.organiser.platform.repository.EventParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Persists the reviewPromptSent flag in its own transaction (REQUIRES_NEW) so
+ * the commit is immediate and independent of the caller's outer transaction.
+ *
+ * This prevents the scheduler from re-sending review emails when the outer
+ * batch transaction rolls back after an email has already been delivered.
+ */
+@Service
+@RequiredArgsConstructor
+public class ReviewPromptFlagService {
+
+    private final EventParticipantRepository eventParticipantRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markPromptSent(EventParticipant ep) {
+        ep.setReviewPromptSent(true);
+        eventParticipantRepository.save(ep);
+    }
+}


### PR DESCRIPTION
Without an explicit save(), dirty-checking on @Scheduled/@Transactional methods
was unreliable — the flag wasn't persisted, so the scheduler re-sent emails on
every daily run.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
